### PR TITLE
Feature/verify multiple mocks at once

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vdstack/mockit",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Behaviour mocking library for TypeScript",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/__tests__/verify/verify.spec.ts
+++ b/src/__tests__/verify/verify.spec.ts
@@ -1,5 +1,12 @@
 import { z } from "zod";
-import { mockFunction, suppose, verify } from "../../mockit";
+import {
+  mock,
+  mockAbstract,
+  mockFunction,
+  mockInterface,
+  suppose,
+  verify,
+} from "../../mockit";
 
 function hello(..._args: any[]) {}
 
@@ -143,5 +150,40 @@ describe("suppose then verify", () => {
     mock2();
 
     verify(mock, mock2);
+  });
+
+  it("should allow to verify structured mocks (classes & interfaces) instead of their individual functions", () => {
+    interface HelloInterface {
+      hello(..._args: any[]): void;
+    }
+
+    class HelloClass {
+      hello(..._args: any[]): void {}
+    }
+
+    abstract class HelloAbstractClass {
+      abstract hello(..._args: any[]): void;
+    }
+
+    const interfaceMock = mockInterface<HelloInterface>("hello");
+
+    suppose(interfaceMock.hello).willBeCalled.once();
+    expect(() => verify(interfaceMock)).toThrow();
+    interfaceMock.hello();
+    verify(interfaceMock);
+
+    const classMock = mock(HelloClass);
+    suppose(classMock.hello).willBeCalled.once();
+    expect(() => verify(classMock)).toThrow();
+    classMock.hello();
+    verify(classMock);
+
+    const abstractClassMock = mockAbstract(HelloAbstractClass, ["hello"]);
+    suppose(abstractClassMock.hello).willBeCalled.once();
+    expect(() => verify(abstractClassMock)).toThrow();
+    abstractClassMock.hello();
+    verify(abstractClassMock);
+
+    verify(interfaceMock, classMock, abstractClassMock);
   });
 });

--- a/src/__tests__/verify/verify.spec.ts
+++ b/src/__tests__/verify/verify.spec.ts
@@ -136,6 +136,9 @@ describe("suppose then verify", () => {
     expect(() => verify(mock, mock2)).toThrow();
 
     mock();
+
+    expect(() => verify(mock, mock2)).toThrow();
+
     mock2();
     mock2();
 

--- a/src/__tests__/verify/verify.spec.ts
+++ b/src/__tests__/verify/verify.spec.ts
@@ -125,4 +125,20 @@ describe("suppose then verify", () => {
     mock("hello");
     expect(() => verify(mock)).toThrow();
   });
+
+  it("should allow to verify multiple mocks in one call", () => {
+    const mock = mockFunction(hello);
+    const mock2 = mockFunction(hello);
+
+    suppose(mock).willBeCalled.once();
+    suppose(mock2).willBeCalled.twice();
+
+    expect(() => verify(mock, mock2)).toThrow();
+
+    mock();
+    mock2();
+    mock2();
+
+    verify(mock, mock2);
+  });
 });

--- a/src/examples/verify-business-logic.spec.ts
+++ b/src/examples/verify-business-logic.spec.ts
@@ -61,8 +61,7 @@ it("should only call minor registration if user is minor", () => {
     { createAdult: adultRegistrationMock, createMinor: minorRegistrationMock }
   );
 
-  verify(minorRegistrationMock);
-  verify(adultRegistrationMock);
+  verify(minorRegistrationMock, adultRegistrationMock);
 });
 
 it("should only call adult registration if user is adult", () => {
@@ -81,6 +80,5 @@ it("should only call adult registration if user is adult", () => {
     { createAdult: adultRegistrationMock, createMinor: minorRegistrationMock }
   );
 
-  verify(adultRegistrationMock);
-  verify(minorRegistrationMock);
+  verify(adultRegistrationMock, minorRegistrationMock);
 });

--- a/src/suppose/verify.ts
+++ b/src/suppose/verify.ts
@@ -8,6 +8,16 @@ export function verify(...mocks: any[]) {
       "suppositionsMap"
     ) as SuppositionRegistry;
 
+    if (suppositions == null) {
+      // We're in the class or abstract class or interface mock case
+      const properties = Object.getOwnPropertyNames(mock);
+      for (const property of properties) {
+        verify(mock[property]);
+      }
+
+      return;
+    }
+
     const spy = new FunctionSpy(mock);
 
     const defaultNever = suppositions

--- a/src/suppose/verify.ts
+++ b/src/suppose/verify.ts
@@ -1,53 +1,55 @@
 import { FunctionSpy } from "../internal/functionSpy";
 import { SuppositionRegistry } from ".";
 
-export function verify(mock: any) {
-  const suppositions = Reflect.get(
-    mock,
-    "suppositionsMap"
-  ) as SuppositionRegistry;
+export function verify(...mocks: any[]) {
+  for (const mock of mocks) {
+    const suppositions = Reflect.get(
+      mock,
+      "suppositionsMap"
+    ) as SuppositionRegistry;
 
-  const spy = new FunctionSpy(mock);
+    const spy = new FunctionSpy(mock);
 
-  const defaultNever = suppositions
-    .getSuppositions()
-    .find((s) => s.count === "NEVER" && s.args == null);
+    const defaultNever = suppositions
+      .getSuppositions()
+      .find((s) => s.count === "NEVER" && s.args == null);
 
-  // This means it should never be called PERIOD, not matter which suppositions you added.
-  if (defaultNever != null) {
-    if (spy.wasCalled.atLeastOnce) {
+    // This means it should never be called PERIOD, not matter which suppositions you added.
+    if (defaultNever != null) {
+      if (spy.wasCalled.atLeastOnce) {
+        throw new Error("Verification failed");
+      }
+    }
+
+    const analysis = suppositions.getSuppositions().map((supposition) => {
+      if (supposition.count === "NEVER") {
+        if (supposition.args == null) {
+          return !spy.wasCalled.atLeastOnce;
+        }
+
+        return !spy.wasCalledWith(...supposition.args).atLeastOnce;
+      }
+
+      if (supposition.count === "atLeastOnce") {
+        if (supposition.args == null) {
+          return spy.wasCalled.atLeastOnce;
+        }
+
+        return spy.wasCalledWith(...supposition.args).atLeastOnce;
+      }
+
+      if (supposition.args == null) {
+        return spy.wasCalled.nTimes(supposition.count);
+      }
+
+      return spy.wasCalledWith(...supposition.args).nTimes(supposition.count);
+    });
+
+    if (analysis.some((a) => a === false)) {
       throw new Error("Verification failed");
     }
+
+    // TODO: beautiful error message with lots of details
+    // TODO: safeVerify that does not throw but instead returns the analysis with details
   }
-
-  const analysis = suppositions.getSuppositions().map((supposition) => {
-    if (supposition.count === "NEVER") {
-      if (supposition.args == null) {
-        return !spy.wasCalled.atLeastOnce;
-      }
-
-      return !spy.wasCalledWith(...supposition.args).atLeastOnce;
-    }
-
-    if (supposition.count === "atLeastOnce") {
-      if (supposition.args == null) {
-        return spy.wasCalled.atLeastOnce;
-      }
-
-      return spy.wasCalledWith(...supposition.args).atLeastOnce;
-    }
-
-    if (supposition.args == null) {
-      return spy.wasCalled.nTimes(supposition.count);
-    }
-
-    return spy.wasCalledWith(...supposition.args).nTimes(supposition.count);
-  });
-
-  if (analysis.some((a) => a === false)) {
-    throw new Error("Verification failed");
-  }
-
-  // TODO: beautiful error message with lots of details
-  // TODO: safeVerify that does not throw but instead returns the analysis with details
 }

--- a/src/suppose/verify.ts
+++ b/src/suppose/verify.ts
@@ -58,8 +58,5 @@ export function verify(...mocks: any[]) {
     if (analysis.some((a) => a === false)) {
       throw new Error("Verification failed");
     }
-
-    // TODO: beautiful error message with lots of details
-    // TODO: safeVerify that does not throw but instead returns the analysis with details
   }
 }


### PR DESCRIPTION
This PR adds two features to make the verification of mocks less verbose and more user-friendly: 

- It's now possible to verify multiple mocks with one `verify(mock1, mock2, mock3, ..., mockN)` call instead of n `verify(mockX)` calls.
- Until now, you could only verify mocked functions. It worked with classes & interfaces mocks by passing as a parameter which function you needed to verify. I added the possibility to check the whole mocked class by internally verifying which type of mock it is, and in the case of a class or interface mock, calling itself on each of their functions.

This is not breaking, only an enhancement of the current API, so I updated to a corrective version: 1.0.0 => 1.0.1