### PR TITLE
Feature: chain suppositions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vdstack/mockit",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Behaviour mocking library for TypeScript",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vdstack/mockit",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Behaviour mocking library for TypeScript",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/__tests__/verify/suppose.chain.spec.ts
+++ b/src/__tests__/verify/suppose.chain.spec.ts
@@ -1,0 +1,23 @@
+import { mockFunction, suppose, verify } from "../../mockit";
+
+function hello(...args: any[]) {}
+
+describe("suppose chain", () => {
+  test("you should be able to chain suppositions on a single mock in a single suppose call", () => {
+    const mock = mockFunction(hello);
+    suppose(mock)
+      .willBeCalled.atLeastOnce()
+      .and.willBeCalledWith(2)
+      .once()
+      .and.willBeCalledWith(3)
+      .twice();
+
+    mock(2);
+    mock(3);
+
+    expect(() => verify(mock)).toThrow();
+
+    mock(3);
+    verify(mock);
+  });
+});

--- a/src/examples/verify-business-logic.spec.ts
+++ b/src/examples/verify-business-logic.spec.ts
@@ -47,7 +47,7 @@ function createAccount(
 it("should only call minor registration if user is minor", () => {
   const adultRegistrationMock = mockFunction(registerAdultAccount);
   const minorRegistrationMock = mockFunction(registerMinorAccount);
-  suppose(minorRegistrationMock).willBeCalledWith(minorSchema).once;
+  suppose(minorRegistrationMock).willBeCalledWith(minorSchema).once();
   suppose(adultRegistrationMock).willNotBeCalled();
 
   createAccount(
@@ -68,7 +68,7 @@ it("should only call adult registration if user is adult", () => {
   const adultRegistrationMock = mockFunction(registerAdultAccount);
   const minorRegistrationMock = mockFunction(registerMinorAccount);
   suppose(minorRegistrationMock).willNotBeCalled();
-  suppose(adultRegistrationMock).willBeCalledWith(adultSchema).once;
+  suppose(adultRegistrationMock).willBeCalledWith(adultSchema).once();
 
   createAccount(
     {

--- a/src/suppose/index.ts
+++ b/src/suppose/index.ts
@@ -16,89 +16,152 @@ export class SuppositionRegistry {
   }
 }
 
-export function suppose(mock: any) {
+export function suppose(mock: any): SupposeResponse {
   const suppositionsMap = Reflect.get(
     mock,
     "suppositionsMap"
   ) as SuppositionRegistry;
+
+  const followup: {
+    and: SupposeResponse;
+  } = {
+    get and() {
+      return suppose(mock);
+    },
+  };
+
   return {
     willNotBeCalled() {
-      return suppositionsMap.addSupposition({
+      suppositionsMap.addSupposition({
         args: undefined,
         count: "NEVER",
       });
+
+      return followup;
     },
     willNotBeCalledWith(...args: any[]) {
-      return suppositionsMap.addSupposition({
+      suppositionsMap.addSupposition({
         args,
         count: "NEVER",
       });
+
+      return followup;
     },
     willBeCalled: {
       atLeastOnce() {
-        return suppositionsMap.addSupposition({
+        suppositionsMap.addSupposition({
           args: undefined,
           count: "atLeastOnce",
         });
+
+        return followup;
       },
       once() {
-        return suppositionsMap.addSupposition({
+        suppositionsMap.addSupposition({
           args: undefined,
           count: 1,
         });
+
+        return followup;
       },
       twice() {
-        return suppositionsMap.addSupposition({
+        suppositionsMap.addSupposition({
           args: undefined,
           count: 2,
         });
+
+        return followup;
       },
       thrice() {
-        return suppositionsMap.addSupposition({
+        suppositionsMap.addSupposition({
           args: undefined,
           count: 3,
         });
+
+        return followup;
       },
       nTimes(n: number) {
-        return suppositionsMap.addSupposition({
+        suppositionsMap.addSupposition({
           args: undefined,
           count: n,
         });
+
+        return followup;
       },
     },
     willBeCalledWith(...args: any[]) {
       return {
         atLeastOnce() {
-          return suppositionsMap.addSupposition({
+          suppositionsMap.addSupposition({
             args,
             count: "atLeastOnce",
           });
+
+          return followup;
         },
         once() {
-          return suppositionsMap.addSupposition({
+          suppositionsMap.addSupposition({
             args,
             count: 1,
           });
+
+          return followup;
         },
         twice() {
-          return suppositionsMap.addSupposition({
+          suppositionsMap.addSupposition({
             args,
             count: 2,
           });
+
+          return followup;
         },
         thrice() {
-          return suppositionsMap.addSupposition({
+          suppositionsMap.addSupposition({
             args,
             count: 3,
           });
+
+          return followup;
         },
         nTimes(n: number) {
-          return suppositionsMap.addSupposition({
+          suppositionsMap.addSupposition({
             args,
             count: n,
           });
+
+          return followup;
         },
       };
     },
   };
 }
+
+type SuppositionSugar = {
+  atLeastOnce(): {
+    and: SupposeResponse;
+  };
+  once(): {
+    and: SupposeResponse;
+  };
+  twice(): {
+    and: SupposeResponse;
+  };
+  thrice(): {
+    and: SupposeResponse;
+  };
+  nTimes(n: number): {
+    and: SupposeResponse;
+  };
+};
+
+type SupposeResponse = {
+  willNotBeCalled(): {
+    and: SupposeResponse;
+  };
+  willNotBeCalledWith(...args: any[]): {
+    and: SupposeResponse;
+  };
+
+  willBeCalled: SuppositionSugar;
+  willBeCalledWith(...args: any[]): SuppositionSugar;
+};


### PR DESCRIPTION
**Until now**
The only way to make multiple suppositions on a single mock was to call `suppose` multiple times. This can become a pain when the dev wants to verify that a mock has been called X number of times AND with different arguments.


**Now**
You can chain suppositions like this:
```ts
const mock = mockFunction(f);
suppose(mock)
  .willBeCalledWith("Victor").once()
  .and.willBeCalledWith("Lisa").once();

// ... do something.

verify(mock);
```

I also stopped using inference for the supposition and declared the result of the function manually. (It's still a recursive type though).

I bumped semver to 1.1.0 since it's retro-compatible