### PR TITLE
refacto: abstract the property access logic behind an interface

### DIFF
--- a/src/internal/functionMock/accessors.ts
+++ b/src/internal/functionMock/accessors.ts
@@ -1,0 +1,104 @@
+import { SuppositionRegistry } from "../../suppose";
+import { HashingMap } from "../../utils/HashingMap";
+import { Call, FunctionCalls } from "../functionSpy";
+
+import { type NewBehaviourParam } from "./behaviour";
+
+/**
+ * This function extracts the mockMap from the proxy's target
+ * @param target the proxy's target
+ */
+function getMocksMap(target: any) {
+  const mockMap: HashingMap = Reflect.get(target, "mockMap");
+  if (!mockMap) {
+    throw new Error("The target is not a mock");
+  }
+
+  return mockMap;
+}
+
+/**
+ * This function extracts the callsMap from the proxy's target
+ * It is used by the spy to access and manipulates the map between arguments and calls
+ * @param target the proxy's target
+ * @returns the callsMap from the proxy's target
+ */
+function getCallsMap(target: any) {
+  const callsMap: FunctionCalls = Reflect.get(target, "callsMap");
+  if (!callsMap) {
+    throw new Error("The target is not a mock");
+  }
+
+  return callsMap;
+}
+
+function getDefaultBehaviour(target: any) {
+  const defaultBehaviour: NewBehaviourParam = Reflect.get(
+    target,
+    "defaultBehaviour"
+  );
+  if (!defaultBehaviour) {
+    throw new Error("The target is not a mock");
+  }
+
+  return defaultBehaviour;
+}
+
+function getCalls(target: any) {
+  const calls: Call[] = Reflect.get(target, "calls");
+  if (!calls) {
+    throw new Error("The target is not a mock");
+  }
+
+  return calls;
+}
+
+function getFunctionName(target: any) {
+  const functionName: string = Reflect.get(target, "functionName");
+  if (!functionName) {
+    throw new Error("The target is not a mock");
+  }
+
+  return functionName;
+}
+
+function getSuppositionsRegistry(target: any) {
+  const suppositionsRegistry: SuppositionRegistry = Reflect.get(
+    target,
+    "suppositionsMap"
+  );
+
+  // Not throwing an error here because the suppositionsRegistry is optional
+  // And we're using its absence to know if requested target is a mock or not
+
+  return suppositionsRegistry;
+}
+
+/**
+ * This function is here to abstract the Reflect.get API calls from the rest of the code.
+ * @param mock The mock to extract information from
+ * @returns A list of getters from which you can access data from the mock, in a more readable way
+ * and with types to help you.
+ */
+export function MockGetters(mock: any) {
+  return {
+    get defaultBehaviour() {
+      return getDefaultBehaviour(mock);
+    },
+    get callsMap() {
+      return getCallsMap(mock);
+    },
+    get mockMap() {
+      return getMocksMap(mock);
+    },
+    get calls() {
+      return getCalls(mock);
+    },
+    get functionName() {
+      return getFunctionName(mock);
+    },
+    get suppositionsRegistry() {
+      return getSuppositionsRegistry(mock);
+    },
+  };
+}

--- a/src/internal/functionMock/applyCatch.ts
+++ b/src/internal/functionMock/applyCatch.ts
@@ -1,11 +1,10 @@
-import { HashingMap } from "../../utils/HashingMap";
 import { Behaviour, NewBehaviourParam } from "./behaviour";
 
-import { FunctionCalls } from "../functionSpy";
+import { MockGetters } from "./accessors";
 
-export function applyCatch(_target, _thisArg, argumentsList) {
+export function applyCatch(target, _thisArg, argumentsList) {
   // Checking if there is a custom behaviour for this call
-  const mockMap: HashingMap = Reflect.get(_target, "mockMap");
+  const mockMap = MockGetters(target).mockMap;
 
   const behaviourWithTheseArguments = mockMap.get(argumentsList) as {
     calls: any[];
@@ -16,21 +15,21 @@ export function applyCatch(_target, _thisArg, argumentsList) {
 
   // Default behaviour
   if (!behaviour) {
-    behaviour = Reflect.get(_target, "defaultBehaviour");
+    behaviour = MockGetters(target).defaultBehaviour;
   }
 
   // Adding the call to the list of calls, for the spy
-  const calls = Reflect.get(_target, "calls");
+  const calls = MockGetters(target).calls;
   calls.push({
     args: argumentsList,
     behaviour,
   });
 
-  const callsMap: FunctionCalls = Reflect.get(_target, "callsMap");
+  const callsMap = MockGetters(target).callsMap;
   callsMap.registerCall(argumentsList, behaviour);
-  Reflect.set(_target, "callsMap", callsMap);
+  Reflect.set(target, "callsMap", callsMap);
 
-  Reflect.set(_target, "calls", calls);
+  Reflect.set(target, "calls", calls);
 
   switch (behaviour.behaviour) {
     case Behaviour.Return:

--- a/src/internal/functionMock/behaviour.ts
+++ b/src/internal/functionMock/behaviour.ts
@@ -1,3 +1,4 @@
+// I'm still wondering if I should just used a restricted string type instead of an enum.
 export enum Behaviour {
   Resolve,
   Reject,
@@ -6,6 +7,10 @@ export enum Behaviour {
   Throw,
 }
 
+/**
+ * This is a discriminated union type that will be used to define behaviours, either
+ * by default or for a call with a specific set of arguments.
+ */
 export type NewBehaviourParam =
   | { behaviour: Behaviour.Throw; error?: any }
   | { behaviour: Behaviour.Call; callback: (...args: any[]) => any }

--- a/src/internal/functionMock/getCatch.ts
+++ b/src/internal/functionMock/getCatch.ts
@@ -1,26 +1,19 @@
-import { HashingMap } from "../../utils/HashingMap";
-import { SuppositionRegistry } from "../../suppose";
-
-import { FunctionCalls } from "../functionSpy";
+import { MockGetters } from "./accessors";
 
 export function getCatch(target, prop, _receiver) {
   switch (prop) {
-    case "calls":
     case "defaultBehaviour":
+      return MockGetters(target).defaultBehaviour;
+    case "calls":
+      return MockGetters(target).calls;
     case "functionName":
-      return Reflect.get(target, prop);
+      return MockGetters(target).functionName;
     case "mockMap":
-      const mockMap = Reflect.get(target, "mockMap") as HashingMap;
-      return mockMap;
+      return MockGetters(target).mockMap;
     case "callsMap":
-      const callsMap = Reflect.get(target, "callsMap") as FunctionCalls;
-      return callsMap;
+      return MockGetters(target).callsMap;
     case "suppositionsMap":
-      const suppositionsMap = Reflect.get(
-        target,
-        "suppositionsMap"
-      ) as SuppositionRegistry;
-      return suppositionsMap;
+      return MockGetters(target).suppositionsRegistry;
     default:
       throw new Error("Unauthorized property");
   }

--- a/src/internal/functionMock/setCatch.ts
+++ b/src/internal/functionMock/setCatch.ts
@@ -1,4 +1,5 @@
 import { HashingMap } from "../../utils/HashingMap";
+import { MockGetters } from "./accessors";
 import { NewBehaviourParam } from "./behaviour";
 
 export function setCatch(target, prop, newValue, receiver) {
@@ -26,7 +27,7 @@ export function setCatch(target, prop, newValue, receiver) {
         customBehaviour: NewBehaviourParam;
       };
 
-      const mockMap: HashingMap = Reflect.get(target, "mockMap");
+      const mockMap: HashingMap = MockGetters(target).mockMap;
       const existingCustomBehaviour = mockMap.get(args) as {
         calls: any[];
         customBehaviour: NewBehaviourParam;

--- a/src/internal/functionSpy/index.ts
+++ b/src/internal/functionSpy/index.ts
@@ -3,19 +3,17 @@ import { countMatchingCalls } from "../../utils/countMatchingCalls";
 import { argsContainZodSchema } from "../../utils/argsContainZodSchema";
 
 import { NewBehaviourParam } from "../functionMock/behaviour";
+import { MockGetters } from "../functionMock/accessors";
 
 export class FunctionSpy {
   constructor(private proxy: any) {}
 
   private get callsMap() {
-    return Reflect.get(this.proxy, "callsMap") as FunctionCalls;
+    return MockGetters(this.proxy).callsMap;
   }
 
   public get calls() {
-    return Reflect.get(this.proxy, "calls") as {
-      args: any[];
-      behaviour: NewBehaviourParam;
-    }[];
+    return MockGetters(this.proxy).calls;
   }
 
   public get wasCalled() {
@@ -110,6 +108,7 @@ export class FunctionSpy {
 }
 
 export type Call = {
+  args?: any[];
   behaviour: NewBehaviourParam;
 };
 

--- a/src/suppose/index.ts
+++ b/src/suppose/index.ts
@@ -1,3 +1,5 @@
+import { MockGetters } from "../internal/functionMock/accessors";
+
 export type SuppositionCount = "atLeastOnce" | "NEVER" | number;
 export type Supposition = {
   args: any[] | undefined;
@@ -17,10 +19,7 @@ export class SuppositionRegistry {
 }
 
 export function suppose(mock: any): SupposeResponse {
-  const suppositionsMap = Reflect.get(
-    mock,
-    "suppositionsMap"
-  ) as SuppositionRegistry;
+  const suppositionsRegistry = MockGetters(mock).suppositionsRegistry;
 
   const followup: {
     and: SupposeResponse;
@@ -32,7 +31,7 @@ export function suppose(mock: any): SupposeResponse {
 
   return {
     willNotBeCalled() {
-      suppositionsMap.addSupposition({
+      suppositionsRegistry.addSupposition({
         args: undefined,
         count: "NEVER",
       });
@@ -40,7 +39,7 @@ export function suppose(mock: any): SupposeResponse {
       return followup;
     },
     willNotBeCalledWith(...args: any[]) {
-      suppositionsMap.addSupposition({
+      suppositionsRegistry.addSupposition({
         args,
         count: "NEVER",
       });
@@ -49,7 +48,7 @@ export function suppose(mock: any): SupposeResponse {
     },
     willBeCalled: {
       atLeastOnce() {
-        suppositionsMap.addSupposition({
+        suppositionsRegistry.addSupposition({
           args: undefined,
           count: "atLeastOnce",
         });
@@ -57,7 +56,7 @@ export function suppose(mock: any): SupposeResponse {
         return followup;
       },
       once() {
-        suppositionsMap.addSupposition({
+        suppositionsRegistry.addSupposition({
           args: undefined,
           count: 1,
         });
@@ -65,7 +64,7 @@ export function suppose(mock: any): SupposeResponse {
         return followup;
       },
       twice() {
-        suppositionsMap.addSupposition({
+        suppositionsRegistry.addSupposition({
           args: undefined,
           count: 2,
         });
@@ -73,7 +72,7 @@ export function suppose(mock: any): SupposeResponse {
         return followup;
       },
       thrice() {
-        suppositionsMap.addSupposition({
+        suppositionsRegistry.addSupposition({
           args: undefined,
           count: 3,
         });
@@ -81,7 +80,7 @@ export function suppose(mock: any): SupposeResponse {
         return followup;
       },
       nTimes(n: number) {
-        suppositionsMap.addSupposition({
+        suppositionsRegistry.addSupposition({
           args: undefined,
           count: n,
         });
@@ -92,7 +91,7 @@ export function suppose(mock: any): SupposeResponse {
     willBeCalledWith(...args: any[]) {
       return {
         atLeastOnce() {
-          suppositionsMap.addSupposition({
+          suppositionsRegistry.addSupposition({
             args,
             count: "atLeastOnce",
           });
@@ -100,7 +99,7 @@ export function suppose(mock: any): SupposeResponse {
           return followup;
         },
         once() {
-          suppositionsMap.addSupposition({
+          suppositionsRegistry.addSupposition({
             args,
             count: 1,
           });
@@ -108,7 +107,7 @@ export function suppose(mock: any): SupposeResponse {
           return followup;
         },
         twice() {
-          suppositionsMap.addSupposition({
+          suppositionsRegistry.addSupposition({
             args,
             count: 2,
           });
@@ -116,7 +115,7 @@ export function suppose(mock: any): SupposeResponse {
           return followup;
         },
         thrice() {
-          suppositionsMap.addSupposition({
+          suppositionsRegistry.addSupposition({
             args,
             count: 3,
           });
@@ -124,7 +123,7 @@ export function suppose(mock: any): SupposeResponse {
           return followup;
         },
         nTimes(n: number) {
-          suppositionsMap.addSupposition({
+          suppositionsRegistry.addSupposition({
             args,
             count: n,
           });


### PR DESCRIPTION
**Until now**
Accessing the properties of a mock required to use the `Reflect.get()` API.

**Issue**
While this is still mandatory, it's a bit all over the place. And in the eventuality of a back-end rewrite it's better to abstract it behind a centralized interface.

**Now**
A `MockGetters` utils is exposed in the `functionMock` folder, and gives access to getters that mimick a simple object but contain hidden calls to the Reflect.get api inside.

Before
`const callsMap: FunctionCalls = Reflect.get(_target, "callsMap");`

After
`const callsMap = MockGetters(target).callsMap;`

Notice how the types are infered from the getter now, preventing many unwanted exports when inference was enough.