### PR TITLE
refacto: abstract Reflect.set behind a setters object

### DIFF
--- a/src/internal/functionMock/accessors.ts
+++ b/src/internal/functionMock/accessors.ts
@@ -65,7 +65,7 @@ function getFunctionName(target: any) {
 function getSuppositionsRegistry(target: any) {
   const suppositionsRegistry: SuppositionRegistry = Reflect.get(
     target,
-    "suppositionsMap"
+    "suppositionsRegistry"
   );
 
   // Not throwing an error here because the suppositionsRegistry is optional
@@ -99,6 +99,78 @@ export function MockGetters(mock: any) {
     },
     get suppositionsRegistry() {
       return getSuppositionsRegistry(mock);
+    },
+  };
+}
+
+export function setMockMap(target: any, mockMap: HashingMap) {
+  Reflect.set(target, "mockMap", mockMap);
+}
+
+export function setCallsMap(target: any, callsMap: FunctionCalls) {
+  Reflect.set(target, "callsMap", callsMap);
+}
+
+export function setCalls(target: any, callsMap: Call[]) {
+  Reflect.set(target, "calls", callsMap);
+}
+
+export function setFunctionName(target: any, functionName: string) {
+  Reflect.set(target, "functionName", functionName);
+}
+
+export function setSuppositionsRegistry(
+  target: any,
+  suppositionsRegistry: SuppositionRegistry
+) {
+  Reflect.set(target, "suppositionsRegistry", suppositionsRegistry);
+}
+
+export function setDefaultBehaviour(
+  target: any,
+  defaultBehaviour: NewBehaviourParam
+) {
+  Reflect.set(target, "defaultBehaviour", defaultBehaviour);
+}
+
+export function registerNewCustomBehaviour(
+  target: any,
+  params: {
+    behaviour: NewBehaviourParam;
+    args: any[];
+  }
+) {
+  Reflect.set(target, "newCustomBehaviour", {
+    customBehaviour: params.behaviour,
+    args: params.args,
+  });
+}
+
+export function MockSetters(mock: any) {
+  return {
+    set mockMap(mockMap: HashingMap) {
+      setMockMap(mock, mockMap);
+    },
+    set callsMap(callsMap: FunctionCalls) {
+      setCallsMap(mock, callsMap);
+    },
+    set calls(calls: Call[]) {
+      setCalls(mock, calls);
+    },
+    set functionName(functionName: string) {
+      setFunctionName(mock, functionName);
+    },
+    set suppositionsRegistry(suppositionsRegistry: SuppositionRegistry) {
+      setSuppositionsRegistry(mock, suppositionsRegistry);
+    },
+    set defaultBehaviour(defaultBehaviour: NewBehaviourParam) {
+      setDefaultBehaviour(mock, defaultBehaviour);
+    },
+    registerNewCustomBehaviour(params: {
+      behaviour: NewBehaviourParam;
+      args: any[];
+    }) {
+      registerNewCustomBehaviour(mock, params);
     },
   };
 }

--- a/src/internal/functionMock/applyCatch.ts
+++ b/src/internal/functionMock/applyCatch.ts
@@ -1,6 +1,6 @@
 import { Behaviour, NewBehaviourParam } from "./behaviour";
 
-import { MockGetters } from "./accessors";
+import { MockGetters, MockSetters } from "./accessors";
 
 export function applyCatch(target, _thisArg, argumentsList) {
   // Checking if there is a custom behaviour for this call
@@ -27,9 +27,9 @@ export function applyCatch(target, _thisArg, argumentsList) {
 
   const callsMap = MockGetters(target).callsMap;
   callsMap.registerCall(argumentsList, behaviour);
-  Reflect.set(target, "callsMap", callsMap);
 
-  Reflect.set(target, "calls", calls);
+  MockSetters(target).callsMap = callsMap;
+  MockSetters(target).calls = calls;
 
   switch (behaviour.behaviour) {
     case Behaviour.Return:

--- a/src/internal/functionMock/getCatch.ts
+++ b/src/internal/functionMock/getCatch.ts
@@ -12,7 +12,7 @@ export function getCatch(target, prop, _receiver) {
       return MockGetters(target).mockMap;
     case "callsMap":
       return MockGetters(target).callsMap;
-    case "suppositionsMap":
+    case "suppositionsRegistry":
       return MockGetters(target).suppositionsRegistry;
     default:
       throw new Error("Unauthorized property");

--- a/src/internal/functionMock/index.ts
+++ b/src/internal/functionMock/index.ts
@@ -8,6 +8,7 @@ import { getCatch } from "./getCatch";
 import { setCatch } from "./setCatch";
 
 import { FunctionMockUtils } from "./utils";
+import { MockSetters } from "./accessors";
 
 export const Behaviours = {
   Return: "Return",
@@ -71,7 +72,7 @@ export function initializeProxy(proxy: any, functionName: string) {
     calls: [],
     mockMap: new HashingMap(),
     callsMap: new FunctionCalls(),
-    suppositionsMap: new SuppositionRegistry(),
+    suppositionsRegistry: new SuppositionRegistry(),
   });
 }
 
@@ -81,5 +82,5 @@ export function changeDefaultBehaviour(
   proxy: any,
   newBehaviour: NewBehaviourParam
 ) {
-  Reflect.set(proxy, "defaultBehaviour", newBehaviour);
+  MockSetters(proxy).defaultBehaviour = newBehaviour;
 }

--- a/src/internal/functionMock/setCatch.ts
+++ b/src/internal/functionMock/setCatch.ts
@@ -1,24 +1,32 @@
 import { HashingMap } from "../../utils/HashingMap";
-import { MockGetters } from "./accessors";
+import { MockGetters, MockSetters } from "./accessors";
 import { NewBehaviourParam } from "./behaviour";
 
 export function setCatch(target, prop, newValue, receiver) {
+  const Setters = MockSetters(target);
   if (prop === "init") {
-    Reflect.set(target, "defaultBehaviour", newValue.defaultBehaviour);
-    Reflect.set(target, "calls", []);
-    Reflect.set(target, "functionName", newValue.functionName);
-    Reflect.set(target, "mockMap", newValue.mockMap);
-    Reflect.set(target, "callsMap", newValue.callsMap);
-    Reflect.set(target, "suppositionsMap", newValue.suppositionsMap);
+    Setters.defaultBehaviour = newValue.defaultBehaviour;
+    Setters.functionName = newValue.functionName;
+    Setters.mockMap = newValue.mockMap;
+    Setters.callsMap = newValue.callsMap;
+    Setters.suppositionsRegistry = newValue.suppositionsRegistry;
+    Setters.calls = [];
+
     return true;
   }
 
   // this will list authorized properties
   switch (prop) {
-    case "defaultBehaviour":
-    case "calls":
+    case "defaultBehaviour": {
+      Setters.defaultBehaviour = newValue;
+      break;
+    }
+    case "calls": {
+      Setters.calls = newValue;
+      break;
+    }
     case "functionName": {
-      Reflect.set(target, prop, newValue);
+      Setters.functionName = newValue;
       break;
     }
     case "newCustomBehaviour": {

--- a/src/internal/functionMock/utils.ts
+++ b/src/internal/functionMock/utils.ts
@@ -1,3 +1,4 @@
+import { MockSetters } from "./accessors";
 import { Behaviour, NewBehaviourParam } from "./behaviour";
 import { initializeProxy, changeDefaultBehaviour } from "./index";
 
@@ -65,51 +66,52 @@ export class FunctionMockUtils {
 
   public callController(...args: any[]) {
     const self = this;
+    const Setters = MockSetters(this.proxy);
     return {
       thenReturn(value: any) {
-        Reflect.set(self.proxy, "newCustomBehaviour", {
-          customBehaviour: {
+        Setters.registerNewCustomBehaviour({
+          args,
+          behaviour: {
             behaviour: Behaviour.Return,
             returnedValue: value,
           },
-          args,
         });
       },
       thenThrow(error: any) {
-        Reflect.set(self.proxy, "newCustomBehaviour", {
-          customBehaviour: {
+        Setters.registerNewCustomBehaviour({
+          args,
+          behaviour: {
             behaviour: Behaviour.Throw,
             error,
           },
-          args,
         });
       },
       thenCall(callback: (...args: any[]) => any) {
-        Reflect.set(self.proxy, "newCustomBehaviour", {
-          customBehaviour: {
+        Setters.registerNewCustomBehaviour({
+          args,
+          behaviour: {
             behaviour: Behaviour.Call,
             callback,
           },
-          args,
         });
       },
       thenResolve(value: any) {
-        Reflect.set(self.proxy, "newCustomBehaviour", {
-          customBehaviour: {
+        Setters.registerNewCustomBehaviour({
+          args,
+          behaviour: {
             behaviour: Behaviour.Resolve,
             resolvedValue: value,
           },
-          args,
         });
       },
 
       thenReject(error: any) {
-        Reflect.set(self.proxy, "newCustomBehaviour", {
-          customBehaviour: {
+        Setters.registerNewCustomBehaviour({
+          args,
+          behaviour: {
             behaviour: Behaviour.Reject,
             rejectedValue: error,
           },
-          args,
         });
       },
     };


### PR DESCRIPTION
This PR follows the previous one (https://github.com/vdstack/mockit/pull/3) and abstracts settings data in mocks proxies behind a Setters object. This helps understand what's happening a bit better since you're not required to read `Reflect.set` everywhere. It's also easier to add stuff under the hood without breaking the fundamental internal API.

**Before**
`Reflect.set(proxy, "defaultBehaviour", newBehaviour);`

**After**
`MockSetters(proxy).defaultBehaviour = newBehaviour;`