### PR TITLE
examples: partially mocked dependencies

### DIFF
--- a/src/examples/mocking-only-one-dependency.spec.ts
+++ b/src/examples/mocking-only-one-dependency.spec.ts
@@ -1,0 +1,93 @@
+/**
+ * Let's say you have a function that uses two dependencies.
+ * Once of them is a repository connected to a database.
+ * The other one is an EmailService that allows you to send emails.
+ *
+ * You might want to test the function with a real DB, but you don't want to send real emails.
+ *
+ * In this case, Mockit can help you by mocking only the email service and verifying that it was called correctly.
+ */
+
+import { mockInterface, suppose, verify, when } from "../mockit";
+
+interface UserRepository {
+  getUserById(id: number): Promise<{ id: number; email: string; name: string }>;
+}
+
+interface EmailService {
+  sendEmail(to: string[], content: string): Promise<{ emailID: number }>;
+}
+
+async function sendWelcomeEmail(
+  userId: number,
+  deps: {
+    userRepository: UserRepository;
+    emailService: EmailService;
+  }
+) {
+  const user = await deps.userRepository.getUserById(userId);
+  if (!user) throw new Error("User not found");
+
+  const { emailID } = await deps.emailService.sendEmail(
+    [user.email],
+    `Welcome ${user.name}!`
+  );
+  if (!emailID) throw new Error("Email not sent");
+
+  return emailID;
+}
+
+/**
+ * For this example I will use an inMemory version of the UserRepository.
+ * In your case you would inject a real implementation connected to your DB.
+ */
+class DBUserRepository implements UserRepository {
+  private users = [];
+  constructor(users: { id: number; email: string; name: string }[]) {
+    // in reality you would probably connect to a DB here or receive a transaction of some sort.
+    this.users = users;
+  }
+
+  async getUserById(id: number) {
+    // Here you would query the DB.
+    return this.users.find((u) => u.id === id);
+  }
+}
+
+test("it should send an email if the user exists and the mail ID", async () => {
+  const user = {
+    email: "user@gmail.com",
+    id: 1,
+    name: "User",
+  };
+
+  // We mock the email service to avoid sending real emails.
+  const emailService = mockInterface<EmailService>("sendEmail");
+  // We configure the mock to return a fake email ID that we will check as a return value.
+  when(emailService.sendEmail).isCalled.thenResolve({ emailID: 1 });
+
+  // We setup an supposition to later verify that the email service was called with the correct arguments.
+  suppose(emailService.sendEmail).willBeCalledWith(
+    [user.email],
+    `Welcome ${user.name}!`
+  );
+
+  const userRepository = new DBUserRepository([
+    {
+      email: "user@gmail.com",
+      id: 1,
+      name: "User",
+    },
+  ]);
+
+  const emailID = await sendWelcomeEmail(1, {
+    emailService,
+    userRepository,
+  });
+
+  // We check that the sendWelcomeEmail function returns the email ID provided by the emailService as expected.
+  expect(emailID).toBe(1);
+
+  // We verify the supposition. It will throw if the supposition fails.
+  verify(emailService);
+});


### PR DESCRIPTION
This PR adds another example that showcases how you can use mockit to mock some dependencies, while testing the others in integration.
This is quite useful when you're interfacing with external dependencies like an email service or a payment service.