### PR TITLE
feat: only accept function params for when method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vdstack/mockit",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Behaviour mocking library for TypeScript",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/mockit.ts
+++ b/src/mockit.ts
@@ -40,7 +40,7 @@ export function mockInterface<T>(...functionsToMock: Array<keyof T>): T {
   return mock as T;
 }
 
-export function when<T>(method: any) {
+export function when<T>(method: (...args: any[]) => any) {
   return {
     /**
      * This function sets up the behaviour of the mocked method.
@@ -86,7 +86,7 @@ export class Mockit {
     return mockAbstract(_original, propertiesToMock);
   }
 
-  static when<T>(method: any) {
+  static when<T>(method: (...args: any[]) => any) {
     return when(method);
   }
 


### PR DESCRIPTION
On usage, we noticed that accepting `any` param for the when method was causing silent, hard to debug test fails. You should be able to pass _what looks like any function_ to when, not _anything_ (in the end you still need to pass our function mocks). This PR strengthens the type to represent that.