### PR TITLE
Feature/reset

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,6 @@ module.exports = {
   preset: "ts-jest",
   // ignore nodemodules
   testPathIgnorePatterns: ["<rootDir>/node_modules/", "<rootDir>/dist/"],
+  // max workers
+  maxWorkers: 1,
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vdstack/mockit",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Behaviour mocking library for TypeScript",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/__tests__/resetMock/reset.spec.ts
+++ b/src/__tests__/resetMock/reset.spec.ts
@@ -8,6 +8,7 @@ import {
   verify,
   mockInterface,
   mockAbstract,
+  Reset,
 } from "../../mockit";
 
 function hello(...args: any[]) {
@@ -132,5 +133,15 @@ describe("Reset mock behaviour", () => {
 
     reset(mock);
     expect(mock.hello("hello")).toBeUndefined();
+  });
+
+  it("should be accessible via Reset static", () => {
+    const mock = mockFunction(hello);
+    when(mock).isCalledWith("hello").thenReturn("hello");
+
+    expect(mock("hello")).toBe("hello");
+
+    Reset.mocks(mock);
+    expect(mock("hello")).toBeUndefined();
   });
 });

--- a/src/__tests__/resetMock/reset.spec.ts
+++ b/src/__tests__/resetMock/reset.spec.ts
@@ -1,0 +1,136 @@
+import {
+  mock as mockClass,
+  mockFunction,
+  when,
+  reset,
+  spy,
+  suppose,
+  verify,
+  mockInterface,
+  mockAbstract,
+} from "../../mockit";
+
+function hello(...args: any[]) {
+  return "world";
+}
+
+describe("Reset mock behaviour", () => {
+  it("should reset default behaviour to undefined return", () => {
+    expect(hello()).toBe("world");
+
+    const mock = mockFunction(hello);
+    expect(mock()).toBeUndefined();
+
+    when(mock).isCalled.thenReturn("WORLD");
+    expect(mock()).toBe("WORLD");
+
+    reset(mock);
+    expect(mock()).toBeUndefined();
+  });
+
+  it("should reset custom behaviours to default behaviour", () => {
+    const mock = mockFunction(hello);
+    when(mock).isCalledWith("hello").thenReturn("hello");
+    when(mock).isCalledWith("world").thenReturn("world");
+
+    expect(mock("hello")).toBe("hello");
+    expect(mock("world")).toBe("world");
+
+    reset(mock);
+    expect(mock("hello")).toBeUndefined();
+    expect(mock("world")).toBeUndefined();
+  });
+
+  it("should reset spies", () => {
+    const mock = mockFunction(hello);
+    when(mock).isCalledWith("hello").thenReturn("hello");
+    when(mock).isCalledWith("world").thenReturn("world");
+    const espion = spy(mock);
+
+    expect(mock("hello")).toBe("hello");
+    expect(mock("world")).toBe("world");
+    expect(espion.wasCalled.twice).toBe(true);
+    expect(espion.wasCalledWith("hello").once).toBe(true);
+    expect(espion.wasCalledWith("world").once).toBe(true);
+
+    reset(mock);
+    expect(espion.wasCalled.twice).toBe(false);
+    expect(espion.wasCalledWith("hello").once).toBe(false);
+    expect(espion.wasCalledWith("world").once).toBe(false);
+    expect(espion.calls.length).toBe(0);
+  });
+
+  it("should reset suppositions", () => {
+    const mock = mockFunction(hello);
+    suppose(mock).willBeCalledWith("hello").atLeastOnce();
+
+    expect(() => verify(mock)).toThrow();
+    mock("hello");
+    verify(mock);
+
+    reset(mock);
+    verify(mock); // should not throw because the mock was reset
+  });
+
+  it("should accept multiple mocks", () => {
+    const mock1 = mockFunction(hello);
+    const mock2 = mockFunction(hello);
+
+    when(mock1).isCalledWith("hello").thenReturn("hello");
+    when(mock2).isCalledWith("world").thenReturn("world");
+
+    expect(mock1("hello")).toBe("hello");
+    expect(mock2("world")).toBe("world");
+
+    reset(mock1, mock2);
+
+    expect(mock1("hello")).toBeUndefined();
+    expect(mock2("world")).toBeUndefined();
+  });
+
+  it("should reset class mocks", () => {
+    class HelloClass {
+      hello(..._args: any[]): void {}
+      HELLAWORLD(..._args: any[]): void {}
+    }
+
+    const mock = mockClass(HelloClass);
+    when(mock.hello).isCalledWith("hello").thenReturn("hello");
+    when(mock.HELLAWORLD).isCalledWith("hello").thenReturn("hello");
+
+    expect(mock.hello("hello")).toBe("hello");
+    expect(mock.HELLAWORLD("hello")).toBe("hello");
+
+    reset(mock);
+    expect(mock.hello("hello")).toBeUndefined();
+    expect(mock.HELLAWORLD("hello")).toBeUndefined();
+  });
+
+  it("should reset interface mocks", () => {
+    interface HelloInterface {
+      hello(..._args: any[]): void;
+    }
+
+    const mock = mockInterface<HelloInterface>("hello");
+    when(mock.hello).isCalledWith("hello").thenReturn("hello");
+
+    expect(mock.hello("hello")).toBe("hello");
+
+    reset(mock);
+    expect(mock.hello("hello")).toBeUndefined();
+  });
+
+  it("should reset abstract class mocks", () => {
+    abstract class HelloAbstractClass {
+      abstract hello(..._args: any[]): void;
+    }
+
+    const mock = mockAbstract(HelloAbstractClass, ["hello"]);
+    when(mock.hello).isCalledWith("hello").thenReturn("hello");
+
+    expect(mock.hello("hello")).toBe("hello");
+
+    reset(mock);
+    expect(mock.hello("hello")).toBeUndefined();
+  });
+});

--- a/src/__tests__/resetMock/resetBehaviour.spec.ts
+++ b/src/__tests__/resetMock/resetBehaviour.spec.ts
@@ -1,0 +1,61 @@
+import { Reset, mockFunction, resetBehaviour, when } from "../../mockit";
+
+describe("It should permit to reset mock behaviour without touching the call history", () => {
+  function hello(...args: any[]) {
+    return "world";
+  }
+
+  it("should reset default behaviour to undefined return", () => {
+    expect(hello()).toBe("world");
+
+    const mock = mockFunction(hello);
+    expect(mock()).toBeUndefined();
+
+    when(mock).isCalled.thenReturn("WORLD");
+    expect(mock()).toBe("WORLD");
+
+    resetBehaviour(mock);
+    expect(mock()).toBeUndefined();
+  });
+
+  it("should reset custom behaviours to default behaviour", () => {
+    const mock = mockFunction(hello);
+    when(mock).isCalledWith("hello").thenReturn("hello");
+    when(mock).isCalledWith("world").thenReturn("world");
+
+    expect(mock("hello")).toBe("hello");
+    expect(mock("world")).toBe("world");
+
+    resetBehaviour(mock);
+    expect(mock("hello")).toBeUndefined();
+    expect(mock("world")).toBeUndefined();
+  });
+
+  it("should be accessible via Reset", () => {
+    const mock = mockFunction(hello);
+    when(mock).isCalledWith("hello").thenReturn("hello");
+    when(mock).isCalledWith("world").thenReturn("world");
+
+    expect(mock("hello")).toBe("hello");
+    expect(mock("world")).toBe("world");
+
+    Reset.behaviourOf(mock);
+    expect(mock("hello")).toBeUndefined();
+    expect(mock("world")).toBeUndefined();
+  });
+
+  it("should work for multiple mocks at once", () => {
+    const mock1 = mockFunction(hello);
+    const mock2 = mockFunction(hello);
+
+    when(mock1).isCalledWith("hello").thenReturn("hello");
+    when(mock2).isCalledWith("world").thenReturn("world");
+
+    expect(mock1("hello")).toBe("hello");
+    expect(mock2("world")).toBe("world");
+
+    resetBehaviour(mock1, mock2);
+    expect(mock1("hello")).toBeUndefined();
+    expect(mock2("world")).toBeUndefined();
+  });
+});

--- a/src/__tests__/resetMock/resetCallHistory.spec.ts
+++ b/src/__tests__/resetMock/resetCallHistory.spec.ts
@@ -1,0 +1,84 @@
+import { verify } from "../../mockit";
+import { mockFunction, spy } from "../../mockit";
+import { Reset, resetCallHistory } from "../../reset";
+import { suppose } from "../../suppose";
+
+describe("It should permit to reset the call history without touching the mock behaviour", () => {
+  function hello(...args: any[]) {
+    return "world";
+  }
+
+  it("should reset the call history", () => {
+    const mock = mockFunction(hello);
+    const mSpy = spy(mock);
+    mock(1);
+    mock(2);
+    mock(3);
+    expect(mSpy.calls.length).toBe(3);
+    resetCallHistory(mock);
+    expect(mSpy.calls.length).toBe(0);
+  });
+
+  it("should reset the call history for multiple mocks at once", () => {
+    const mock1 = mockFunction(hello);
+    const mock2 = mockFunction(hello);
+    const mSpy1 = spy(mock1);
+    const mSpy2 = spy(mock2);
+    mock1(1);
+    mock2(1);
+    mock1(2);
+    mock2(2);
+    mock1(3);
+    mock2(3);
+    expect(mSpy1.calls.length).toBe(3);
+    expect(mSpy2.calls.length).toBe(3);
+    resetCallHistory(mock1, mock2);
+    expect(mSpy1.calls.length).toBe(0);
+    expect(mSpy2.calls.length).toBe(0);
+  });
+
+  it("should reset the saved assertions", () => {
+    const mock = mockFunction(hello);
+    const mSpy = spy(mock);
+    mock(1);
+    mock(2);
+    mock(3);
+    expect(mSpy.wasCalled.thrice).toBe(true);
+    resetCallHistory(mock);
+    expect(mSpy.wasCalled.nTimes(0)).toBe(true);
+  });
+
+  it("should work with verification & suppositions as well", () => {
+    const mock = mockFunction(hello);
+
+    suppose(mock).willBeCalled.thrice();
+    suppose(mock).willBeCalledWith(1, 2, 3).once();
+
+    mock(1, 2, 3);
+    mock();
+    mock();
+
+    verify(mock);
+
+    resetCallHistory(mock);
+
+    expect(() => verify(mock)).toThrow();
+  });
+
+  it("should work with Reset", () => {
+    const mock = mockFunction(hello);
+
+    suppose(mock).willBeCalled.thrice();
+    suppose(mock).willBeCalledWith(1, 2, 3).once();
+
+    mock(1, 2, 3);
+    mock();
+    mock();
+
+    verify(mock);
+
+    Reset.historyOf(mock);
+
+    expect(() => verify(mock)).toThrow();
+  });
+});

--- a/src/__tests__/resetMock/resetSuppositions.spec.ts
+++ b/src/__tests__/resetMock/resetSuppositions.spec.ts
@@ -1,0 +1,80 @@
+import { mockFunction, verify } from "../../mockit";
+import { Reset, resetCallHistory, resetSuppositions } from "../../reset";
+import { suppose } from "../../suppose";
+
+describe("It should permit to reset mock suppositions without touching the call history", () => {
+  function hellaw(...args: any[]) {
+    return "world";
+  }
+
+  it("should reset suppositions and allow to set new ones", () => {
+    const mock = mockFunction(hellaw);
+    suppose(mock).willBeCalled.twice();
+
+    mock();
+    mock();
+
+    verify(mock);
+
+    resetSuppositions(mock);
+
+    suppose(mock).willBeCalled.thrice();
+    expect(() => verify(mock)).toThrowError();
+
+    mock();
+    verify(mock);
+  });
+
+  it("should combine with resetCallHistory", () => {
+    const mock = mockFunction(hellaw);
+    suppose(mock).willBeCalled.twice();
+
+    mock();
+    mock();
+
+    verify(mock);
+
+    resetSuppositions(mock);
+    resetCallHistory(mock);
+
+    suppose(mock).willBeCalled.once();
+    expect(() => verify(mock)).toThrowError();
+    mock();
+
+    verify(mock);
+  });
+
+  it("should work with multiple mocks", () => {
+    const mock1 = mockFunction(hellaw);
+    const mock2 = mockFunction(hellaw);
+    suppose(mock1).willBeCalled.once();
+    suppose(mock2).willBeCalled.once();
+
+    mock1();
+    mock2();
+
+    verify(mock1);
+    verify(mock2);
+
+    resetSuppositions(mock1, mock2);
+
+    suppose(mock1).willBeCalled.once();
+    suppose(mock2).willBeCalled.twice();
+
+    verify(mock1);
+    expect(() => verify(mock2)).toThrowError();
+  });
+
+  it("should work with Reset", () => {
+    const mock = mockFunction(hellaw);
+    suppose(mock).willBeCalled.once();
+    mock();
+    verify(mock);
+
+    Reset.suppositionsOn(mock);
+    suppose(mock).willBeCalled.twice();
+    expect(() => verify(mock)).toThrowError();
+    mock();
+    verify(mock);
+  });
+});

--- a/src/__tests__/resetMock/spy.spec.ts
+++ b/src/__tests__/resetMock/spy.spec.ts
@@ -1,0 +1,26 @@
+import { mockFunction, spy, when } from "../../mockit";
+
+function hello(..._args: any[]): void {}
+
+describe("Spy.reset()", () => {
+  it("should reset spies while maintaining behaviour", () => {
+    const mock = mockFunction(hello);
+    const espion = spy(mock);
+
+    when(mock).isCalledWith("hello").thenReturn("hello");
+    when(mock).isCalledWith("world").thenReturn("world");
+
+    expect(espion.calls.length).toEqual(0);
+    expect(espion.wasCalled.once).toBe(false);
+
+    mock("hello");
+    expect(espion.calls.length).toEqual(1);
+    expect(espion.wasCalled.once).toBe(true);
+
+    espion.reset();
+    expect(espion.calls.length).toEqual(0);
+    expect(espion.wasCalled.once).toBe(false);
+    expect(mock("hello")).toEqual("hello");
+    expect(espion.calls.length).toEqual(1);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,10 @@ import {
   mockAbstract,
   mockFunction,
   mockInterface,
+  reset,
+  Reset,
+  resetBehaviour,
+  resetCallHistory,
   spy,
   suppose,
   verify,
@@ -12,6 +16,10 @@ import {
 
 export {
   Mockit,
+  Reset,
+  reset,
+  resetBehaviour,
+  resetCallHistory,
   mock,
   mockAbstract,
   mockFunction,

--- a/src/internal/functionMock/index.ts
+++ b/src/internal/functionMock/index.ts
@@ -76,6 +76,22 @@ export function initializeProxy(proxy: any, functionName: string) {
   });
 }
 
+export function resetProxyBehaviour(proxy: any) {
+  Reflect.set(proxy, "resetBehaviour", {
+    defaultBehaviour,
+    mockMap: new HashingMap(),
+  });
+}
+
+export function resetProxyCallHistory(proxy: any) {
+  MockSetters(proxy).calls = [];
+  MockSetters(proxy).callsMap = new FunctionCalls();
+}
+
+export function resetProxySuppositions(proxy: any) {
+  MockSetters(proxy).suppositionsRegistry = new SuppositionRegistry();
+}
+
 export function resetProxy(proxy: any) {
   const functionName = MockGetters(proxy).functionName;
   initializeProxy(proxy, functionName);

--- a/src/internal/functionMock/index.ts
+++ b/src/internal/functionMock/index.ts
@@ -8,7 +8,7 @@ import { getCatch } from "./getCatch";
 import { setCatch } from "./setCatch";
 
 import { FunctionMockUtils } from "./utils";
-import { MockSetters } from "./accessors";
+import { MockGetters, MockSetters } from "./accessors";
 
 export const Behaviours = {
   Return: "Return",
@@ -74,6 +74,11 @@ export function initializeProxy(proxy: any, functionName: string) {
     callsMap: new FunctionCalls(),
     suppositionsRegistry: new SuppositionRegistry(),
   });
+}
+
+export function resetProxy(proxy: any) {
+  const functionName = MockGetters(proxy).functionName;
+  initializeProxy(proxy, functionName);
 }
 
 // TODO: expose this in some way to allow users to change the default behaviour

--- a/src/internal/functionMock/setCatch.ts
+++ b/src/internal/functionMock/setCatch.ts
@@ -15,14 +15,34 @@ export function setCatch(target, prop, newValue, receiver) {
     return true;
   }
 
+  if (prop === "resetBehaviour") {
+    Setters.defaultBehaviour = newValue.defaultBehaviour;
+    Setters.mockMap = newValue.mockMap;
+    return true;
+  }
+
+  if (prop === "resetCallHistory") {
+    Setters.calls = [];
+    Setters.callsMap = newValue.callsMap;
+    return true;
+  }
+
   // this will list authorized properties
   switch (prop) {
     case "defaultBehaviour": {
       Setters.defaultBehaviour = newValue;
       break;
     }
+    case "suppositionsRegistry": {
+      Setters.suppositionsRegistry = newValue;
+      break;
+    }
     case "calls": {
       Setters.calls = newValue;
+      break;
+    }
+    case "mockMap": {
+      Setters.mockMap = newValue;
       break;
     }
     case "callsMap": {

--- a/src/internal/functionMock/setCatch.ts
+++ b/src/internal/functionMock/setCatch.ts
@@ -25,6 +25,10 @@ export function setCatch(target, prop, newValue, receiver) {
       Setters.calls = newValue;
       break;
     }
+    case "callsMap": {
+      Setters.callsMap = newValue;
+      break;
+    }
     case "functionName": {
       Setters.functionName = newValue;
       break;

--- a/src/internal/functionSpy/index.ts
+++ b/src/internal/functionSpy/index.ts
@@ -3,7 +3,7 @@ import { countMatchingCalls } from "../../utils/countMatchingCalls";
 import { argsContainZodSchema } from "../../utils/argsContainZodSchema";
 
 import { NewBehaviourParam } from "../functionMock/behaviour";
-import { MockGetters } from "../functionMock/accessors";
+import { MockGetters, MockSetters } from "../functionMock/accessors";
 
 export class FunctionSpy {
   constructor(private proxy: any) {}
@@ -14,6 +14,16 @@ export class FunctionSpy {
 
   public get calls() {
     return MockGetters(this.proxy).calls;
+  }
+
+  /**
+   * Reset the spy data of the mock
+   * BEWARE: any "verify" call will be affected by this reset
+   * because the mock itself will reset its data
+   */
+  public reset() {
+    MockSetters(this.proxy).calls = [];
+    MockSetters(this.proxy).callsMap = new FunctionCalls();
   }
 
   public get wasCalled() {

--- a/src/mockit.ts
+++ b/src/mockit.ts
@@ -17,7 +17,7 @@ import {
 
 import { suppose } from "./suppose";
 import { verify } from "./suppose/verify";
-import { reset } from "./reset";
+import { reset, Reset, resetBehaviour, resetCallHistory } from "./reset";
 
 export function mockAbstract<T>(
   _original: AbstractClass<T>, // it's here to activate the generic type
@@ -58,7 +58,7 @@ export function when<T>(method: (...args: any[]) => any) {
   };
 }
 
-export { suppose, verify, reset };
+export { suppose, verify, reset, resetBehaviour, resetCallHistory, Reset };
 export { Behaviour };
 
 export function spy<T extends (...args: any[]) => any>(

--- a/src/mockit.ts
+++ b/src/mockit.ts
@@ -17,6 +17,7 @@ import {
 
 import { suppose } from "./suppose";
 import { verify } from "./suppose/verify";
+import { reset } from "./reset";
 
 export function mockAbstract<T>(
   _original: AbstractClass<T>, // it's here to activate the generic type
@@ -57,7 +58,7 @@ export function when<T>(method: (...args: any[]) => any) {
   };
 }
 
-export { suppose, verify };
+export { suppose, verify, reset };
 export { Behaviour };
 
 export function spy<T extends (...args: any[]) => any>(
@@ -110,6 +111,7 @@ export class Mockit {
 
   static suppose = suppose;
   static verify = verify;
+  static reset = reset;
 
   static get any() {
     // this is just a port to zod, you can pass zod schemas directly

--- a/src/reset/index.ts
+++ b/src/reset/index.ts
@@ -1,4 +1,9 @@
-import { resetProxy } from "../internal/functionMock";
+import {
+  resetProxy,
+  resetProxyBehaviour,
+  resetProxyCallHistory,
+  resetProxySuppositions,
+} from "../internal/functionMock";
 import { MockGetters } from "../internal/functionMock/accessors";
 
 export function reset<T>(...mocks: T[]): void {
@@ -14,6 +19,75 @@ export function reset<T>(...mocks: T[]): void {
       return;
     }
 
-    resetProxy(m);
+    resetProxy(m); // <--- We reset the function mock
+  }
+}
+
+export function resetBehaviour<T>(...mocks: T[]): void {
+  for (const m of mocks) {
+    const suppositionsRegistry = MockGetters(m).suppositionsRegistry;
+
+    if (suppositionsRegistry == null) {
+      // We're in the class or abstract class or interface mock case
+      const properties = Object.getOwnPropertyNames(m);
+      for (const property of properties) {
+        resetProxyBehaviour(m[property]); // <--- We reset each property (function mock) individually
+      }
+      return;
+    }
+
+    resetProxyBehaviour(m); // <--- We reset the behaviour
+  }
+}
+
+export function resetCallHistory<T>(...mocks: T[]): void {
+  for (const m of mocks) {
+    const suppositionsRegistry = MockGetters(m).suppositionsRegistry;
+
+    if (suppositionsRegistry == null) {
+      // We're in the class or abstract class or interface mock case
+      const properties = Object.getOwnPropertyNames(m);
+      for (const property of properties) {
+        resetProxyCallHistory(m[property]); // <--- We reset each property (function mock) individually
+      }
+      return;
+    }
+
+    resetProxyCallHistory(m); // <--- We reset the call history
+  }
+}
+
+export function resetSuppositions<T>(...mocks: T[]): void {
+  for (const m of mocks) {
+    const suppositionsRegistry = MockGetters(m).suppositionsRegistry;
+
+    if (suppositionsRegistry == null) {
+      // We're in the class or abstract class or interface mock case
+      const properties = Object.getOwnPropertyNames(m);
+      for (const property of properties) {
+        resetProxySuppositions(m[property]); // <--- We reset each property (function mock) individually
+      }
+      return;
+    }
+
+    resetProxySuppositions(m); // <--- We reset the suppositions
+  }
+}
+
+export class Reset {
+  static mocks(...mocks: any[]) {
+    reset(...mocks);
+  }
+
+  static behaviourOf(...mocks: any[]) {
+    resetBehaviour(...mocks);
+  }
+
+  static historyOf(...mocks: any[]) {
+    resetCallHistory(...mocks);
+  }
+
+  static suppositionsOn(...mocks: any[]) {
+    resetSuppositions(...mocks);
   }
 }

--- a/src/reset/index.ts
+++ b/src/reset/index.ts
@@ -1,0 +1,19 @@
+import { resetProxy } from "../internal/functionMock";
+import { MockGetters } from "../internal/functionMock/accessors";
+
+export function reset<T>(...mocks: T[]): void {
+  for (const m of mocks) {
+    const suppositionsRegistry = MockGetters(m).suppositionsRegistry;
+
+    if (suppositionsRegistry == null) {
+      // We're in the class or abstract class or interface mock case
+      const properties = Object.getOwnPropertyNames(m);
+      for (const property of properties) {
+        resetProxy(m[property]); // <--- We reset each property (function mock) individually
+      }
+      return;
+    }
+
+    resetProxy(m);
+  }
+}


### PR DESCRIPTION
This PR adds a utility function that resets any mock you pass as an argument.
It will reset:
- spies
- suppositions
- default behaviours
- custom behaviours

There might be a case for a more partial resets helpers (like, keeping behavior but reset calls history, etc...).
We could also place a reset function inside a spy for specific spied related data reset, and expose resetBehaviour or something.

I'm not sure I will merge as is, but I open the PR to display current train of thoughts.