### PR TITLE
dx: add registered calls information on verification failed

### DIFF
--- a/src/__tests__/verify/verify.spec.ts
+++ b/src/__tests__/verify/verify.spec.ts
@@ -101,7 +101,6 @@ describe("suppose then verify", () => {
     });
     expect(() => verify(mock)).toThrow(); // the last supposition is not complete: it needs another call
 
-    verify(mock);
     mock({
       hello: "hello",
       world: 2,

--- a/src/__tests__/verify/verify.spec.ts
+++ b/src/__tests__/verify/verify.spec.ts
@@ -74,7 +74,7 @@ describe("suppose then verify", () => {
     verify(mock);
   });
 
-  it("should accept multiple complex arguments on multiple suppositions", () => {
+  it.only("should accept multiple complex arguments on multiple suppositions", () => {
     const mock = mockFunction(hello);
     suppose(mock).willBeCalledWith(z.number(), z.string()).once();
     suppose(mock).willBeCalledWith(z.string(), z.number()).once();
@@ -101,6 +101,7 @@ describe("suppose then verify", () => {
     });
     expect(() => verify(mock)).toThrow(); // the last supposition is not complete: it needs another call
 
+    verify(mock);
     mock({
       hello: "hello",
       world: 2,

--- a/src/suppose/verify.ts
+++ b/src/suppose/verify.ts
@@ -82,10 +82,10 @@ export function verify(...mocks: any[]) {
       const suppositionsErrors = `
 ${failedSuppositions
   .map(
-    (a) =>
-      `${parseSuppositionText(a.supposition.count)}${parseSuppositionsArgs(
-        a.supposition.args
-      )}.`
+    (a, index) =>
+      `Supposition ${index + 1}:${parseSuppositionText(
+        a.supposition.count
+      )}${parseSuppositionsArgs(a.supposition.args)}.`
   )
   .join("\n\n")}
       `;
@@ -95,7 +95,7 @@ ${failedSuppositions
       const callsText = parseCallsText(calls);
       const helpText =
         "You can setup a spy and use it to access the history arguments yourself.";
-      const error = `Function "${functionName}" failed its verification\n${callsText}\n${suppositionsErrors}\n${helpText}`;
+      const error = `Function "${functionName}" failed its verification\n${callsText}\n\nRegistered suppositions:${suppositionsErrors}\n${helpText}`;
       throw new Error(error);
     }
   }
@@ -103,14 +103,14 @@ ${failedSuppositions
 
 function parseSuppositionText(supp: SuppositionCount) {
   if (supp === "NEVER") {
-    return "Suppositions:\nIt was expected to never be called";
+    return "\nIt was expected to never be called";
   }
 
   if (supp === "atLeastOnce") {
-    return "Suppositions:\nIt was expected to be called at least once";
+    return "\nIt was expected to be called at least once";
   }
 
-  return `Suppositions:\nIt was expected to be called ${supp} time(s)`;
+  return `\nIt was expected to be called ${supp} time(s)`;
 }
 
 function parseSuppositionsArgs(suppArgs: Supposition["args"]) {
@@ -136,7 +136,9 @@ function parseCallsText(calls: FunctionCalls) {
     )}`;
   }
 
-  const parsedArgs = args.map((a) => JSON.stringify(a, null, 2)).join("\n");
+  const parsedArgs = args
+    .map((a, index) => `Call ${index + 1}:\n ${JSON.stringify(a, null, 2)}`)
+    .join("\n\n");
   return `It was called ${
     timesMap[args.length] ?? `${args.length} times`
   }.\n\nRegistered calls:\n${parsedArgs}`;

--- a/src/suppose/verify.ts
+++ b/src/suppose/verify.ts
@@ -94,7 +94,7 @@ ${failedSuppositions
 
       const callsText = parseCallsText(calls);
       const helpText =
-        "You can setup a spy and use it to access the history arguments yourself.";
+        "Small hint: You can setup a spy and use it to access the history arguments yourself.";
       const error = `Function "${functionName}" failed its verification\n${callsText}\n\nRegistered suppositions:${suppositionsErrors}\n${helpText}`;
       throw new Error(error);
     }

--- a/src/suppose/verify.ts
+++ b/src/suppose/verify.ts
@@ -1,4 +1,4 @@
-import { FunctionSpy } from "../internal/functionSpy";
+import { FunctionCalls, FunctionSpy } from "../internal/functionSpy";
 import { MockGetters } from "../internal/functionMock/accessors";
 import { Supposition, SuppositionCount } from ".";
 
@@ -80,17 +80,22 @@ export function verify(...mocks: any[]) {
       const mockGetter = MockGetters(mock);
       const functionName = mockGetter.functionName;
       const suppositionsErrors = `
-        ${failedSuppositions
-          .map(
-            (a) =>
-              `${parseSuppositionText(
-                a.supposition.count
-              )}${parseSuppositionsArgs(a.supposition.args)}.`
-          )
-          .join("\n\n")}
+${failedSuppositions
+  .map(
+    (a) =>
+      `${parseSuppositionText(a.supposition.count)}${parseSuppositionsArgs(
+        a.supposition.args
+      )}.`
+  )
+  .join("\n\n")}
       `;
 
-      const error = `Function "${functionName}" failed its verification\n${suppositionsErrors}`;
+      const calls = mockGetter.callsMap;
+
+      const callsText = parseCallsText(calls);
+      const helpText =
+        "You can setup a spy and use it to access the history arguments yourself.";
+      const error = `Function "${functionName}" failed its verification\n${callsText}\n${suppositionsErrors}\n${helpText}`;
       throw new Error(error);
     }
   }
@@ -98,14 +103,14 @@ export function verify(...mocks: any[]) {
 
 function parseSuppositionText(supp: SuppositionCount) {
   if (supp === "NEVER") {
-    return "It was expected to never be called";
+    return "Suppositions:\nIt was expected to never be called";
   }
 
   if (supp === "atLeastOnce") {
-    return "It was expected to be called at least once";
+    return "Suppositions:\nIt was expected to be called at least once";
   }
 
-  return `It was expected to be called ${supp} time(s)`;
+  return `Suppositions:\nIt was expected to be called ${supp} time(s)`;
 }
 
 function parseSuppositionsArgs(suppArgs: Supposition["args"]) {
@@ -115,3 +120,29 @@ function parseSuppositionsArgs(suppArgs: Supposition["args"]) {
 
   return ` with arguments: ${JSON.stringify(suppArgs, null, 2)}`;
 }
+
+function parseCallsText(calls: FunctionCalls) {
+  const args = calls.getArgs();
+
+  if (!args.length) {
+    return "It was never called";
+  }
+
+  if (args.length === 1) {
+    return `It was called once with arguments:\n${JSON.stringify(
+      args[0],
+      null,
+      2
+    )}`;
+  }
+
+  const parsedArgs = args.map((a) => JSON.stringify(a, null, 2)).join("\n");
+  return `It was called ${
+    timesMap[args.length] ?? `${args.length} times`
+  }.\n\nRegistered calls:\n${parsedArgs}`;
+}
+
+const timesMap = {
+  1: "once",
+  2: "twice",
+};


### PR DESCRIPTION
This PR adds two things on verification's failure:
- A list of all registered calls to the mock, in order of calls.
- A hint at the end the the assistive error, explaining how to directly access the argument if the dev needs them.

![image](https://user-images.githubusercontent.com/6061078/235369713-7d524e99-3348-4a3f-9a74-dad6379a5e50.png)
![image](https://user-images.githubusercontent.com/6061078/235369736-5b6ebba5-ee62-41dd-bf33-62b1a1dd392a.png)
