### PR TITLE
iteration: better errors messages for verifyThat & add tests for wasCalledWith

### DIFF
--- a/src/__tests__/verifyThat/verifyThat.spec.ts
+++ b/src/__tests__/verifyThat/verifyThat.spec.ts
@@ -57,9 +57,12 @@ describe("Verify that", () => {
   it("should allow to track calls with specific arguments", () => {
     const mockedFunction = mockFunction(hello);
     verifyThat(mockedFunction).wasNeverCalledWith("hello", "world");
-
+    expect(() =>
+      verifyThat(mockedFunction).wasCalledWith("hello", "world")
+    ).toThrow();
     mockedFunction("hello", "world");
 
+    verifyThat(mockedFunction).wasCalledWith("hello", "world");
     verifyThat(mockedFunction).wasCalledOnceWith("hello", "world");
     expect(() =>
       verifyThat(mockedFunction).wasNeverCalledWith("hello", "world")
@@ -69,6 +72,7 @@ describe("Verify that", () => {
     ).toThrow();
 
     mockedFunction("hello", "world");
+    verifyThat(mockedFunction).wasCalledWith("hello", "world");
     verifyThat(mockedFunction).wasCalledTwiceWith("hello", "world");
     expect(() =>
       verifyThat(mockedFunction).wasCalledTwiceWith("hello")
@@ -83,11 +87,13 @@ describe("Verify that", () => {
     const mockedFunction = mockFunction(hiii);
     mockedFunction("hello", 2222);
     verifyThat(mockedFunction).wasCalledOnceWithSafe("hello", 2222);
+    verifyThat(mockedFunction).wasCalledWithSafe("hello", 2222);
     expect(() =>
       verifyThat(mockedFunction).wasCalledOnceWithSafe("hello", 99999)
     ).toThrow();
 
     mockedFunction("hello", 2222);
+    verifyThat(mockedFunction).wasCalledWithSafe("hello", 2222);
     verifyThat(mockedFunction).wasCalledTwiceWithSafe("hello", 2222);
     expect(() =>
       verifyThat(mockedFunction).wasCalledTwiceWithSafe("hello", 99999)
@@ -105,6 +111,9 @@ describe("Verify that", () => {
     expect(() =>
       verifyThat(mockedFunction).wasCalledOnceWith(z.string())
     ).toThrow();
+    expect(() =>
+      verifyThat(mockedFunction).wasCalledWith(z.string())
+    ).toThrow();
 
     mockedFunction();
     mockedFunction("hello", "world");
@@ -114,6 +123,9 @@ describe("Verify that", () => {
     ).toThrow();
     verifyThat(mockedFunction).wasCalledOnceWith(z.string(), z.string());
     verifyThat(mockedFunction).wasCalledOnceWith(z.any(), z.any());
+    verifyThat(mockedFunction).wasCalledWith(z.string(), z.string());
+    verifyThat(mockedFunction).wasCalledWith(z.any(), z.any());
+
     expect(() =>
       verifyThat(mockedFunction).wasCalledOnceWith(
         z.any(),

--- a/src/suppose/verify.ts
+++ b/src/suppose/verify.ts
@@ -121,7 +121,7 @@ function parseSuppositionsArgs(suppArgs: Supposition["args"]) {
   return ` with arguments: ${JSON.stringify(suppArgs, null, 2)}`;
 }
 
-function parseCallsText(calls: FunctionCalls) {
+export function parseCallsText(calls: FunctionCalls) {
   const args = calls.getArgs();
 
   if (!args.length) {

--- a/src/suppose/verifyThat.ts
+++ b/src/suppose/verifyThat.ts
@@ -1,4 +1,7 @@
 import { FunctionSpy } from "../internal";
+import { MockGetters } from "../internal/functionMock/accessors";
+
+import { parseCallsText } from "./verify";
 
 /**
  *
@@ -31,134 +34,150 @@ export function verifyThat<Params extends any[], Result>(
   mockedFunction: (...args: Params) => Result
 ) {
   const spy = new FunctionSpy(mockedFunction);
+
+  const calls = MockGetters(mockedFunction).callsMap;
+  const functionName = MockGetters(mockedFunction).functionName;
+  const callsText = parseCallsText(calls);
+
+  const helpText =
+    "Small hint: You can setup a spy and use it to access the history arguments yourself.";
+  const suffix = `\n${callsText}\n\n${helpText}`;
   return {
     wasCalledWith: (...params: any[]) => {
-      return spy.wasCalledWith(...params);
+      if (!spy.wasCalledWith(...params).atLeastOnce) {
+        throw new Error(
+          `Function "${functionName}" was not called with parameters ${params}${suffix}`
+        );
+      }
     },
     wasCalledWithSafe: (...params: Params) => {
-      return spy.wasCalledWith(...params);
+      if (!spy.wasCalledWith(...params).atLeastOnce) {
+        throw new Error(
+          `Function "${functionName}" was not called with parameters ${params}${suffix}`
+        );
+      }
     },
     wasCalled: () => {
       if (!spy.wasCalled.atLeastOnce) {
-        throw new Error(
-          `Function was not called, but ${spy.calls.length} times`
-        );
+        throw new Error(`Function "${functionName}" was never called.`);
       }
     },
     wasCalledOnce: () => {
       if (!spy.wasCalled.once) {
         throw new Error(
-          `Function was not called exactly once, but ${spy.calls.length} times`
+          `Function "${functionName}" was not called exactly once.${suffix}`
         );
       }
     },
     wasCalledOnceWith: (...params: any[]) => {
       if (!spy.wasCalledWith(...params).once) {
         throw new Error(
-          `Function was not called exactly once with ${params}, but ${spy.calls.length} times`
+          `Function "${functionName}" was not called exactly once with parameters ${params}${suffix}`
         );
       }
     },
     wasCalledOnceWithSafe: (...params: Params) => {
       if (!spy.wasCalledWith(...params).once) {
         throw new Error(
-          `Function was not called exactly once with ${params}, but ${spy.calls.length} times`
+          `Function "${functionName}" was not called exactly once with parameters ${params}${suffix}`
         );
       }
     },
     wasCalledTwice: () => {
       if (!spy.wasCalled.twice) {
         throw new Error(
-          `Function was not called exactly twice, but ${spy.calls.length} times`
+          `Function "${functionName}" was not called exactly twice${suffix}`
         );
       }
     },
     wasCalledTwiceWith: (...params: any[]) => {
       if (!spy.wasCalledWith(...params).twice) {
         throw new Error(
-          `Function was not called exactly twice with ${params}, but ${spy.calls.length} times`
+          `Function "${functionName}" was not called exactly twice with parameters ${params}${suffix}`
         );
       }
     },
     wasCalledTwiceWithSafe: (...params: Params) => {
       if (!spy.wasCalledWith(...params).twice) {
         throw new Error(
-          `Function was not called exactly twice with ${params}, but ${spy.calls.length} times`
+          `Function "${functionName}" was not called exactly twice with parameters ${params}${suffix}`
         );
       }
     },
     wasCalledThrice: () => {
       if (!spy.wasCalled.thrice) {
         throw new Error(
-          `Function was not called exactly thrice, but ${spy.calls.length} times`
+          `Function "${functionName}" was not called exactly thrice${suffix}`
         );
       }
     },
     wasCalledThriceWith: (...params: any[]) => {
       if (!spy.wasCalledWith(...params).thrice) {
         throw new Error(
-          `Function was not called exactly thrice with ${params}, but ${spy.calls.length} times`
+          `Function "${functionName}" was not called exactly thrice with parameters ${params}${suffix}`
         );
       }
     },
     wasCalledThriceWithSafe: (...params: Params) => {
       if (!spy.wasCalledWith(...params).thrice) {
         throw new Error(
-          `Function was not called exactly thrice with ${params}, but ${spy.calls.length} times`
+          `Function "${functionName}" was not called exactly thrice with parameters ${params}${suffix}`
         );
       }
     },
     wasCalledNTimes: (howMuch: number) => {
       if (spy.calls.length !== howMuch) {
         throw new Error(
-          `Function was called ${spy.calls.length} times, expected ${howMuch}`
+          `Function "${functionName}" was called not called ${howMuch} times.${suffix}`
         );
       }
     },
     wasCalledNTimesWith: (howMuch: number, ...params: any[]) => {
       if (spy.calls.length !== howMuch) {
         throw new Error(
-          `Function was called ${spy.calls.length} times, expected ${howMuch}`
+          `Function "${functionName}" was called ${howMuch} times.${suffix}`
         );
       }
       if (!spy.wasCalledWith(...params).nTimes) {
         throw new Error(
-          `Function was not called ${howMuch} times with ${params}`
+          `Function "${functionName}" was not called ${howMuch} times with parameters ${params}${suffix}`
         );
       }
     },
     wasCalledNTimesWithSafe: (howMuch: number, ...params: Params) => {
       if (spy.calls.length !== howMuch) {
         throw new Error(
-          `Function was called ${spy.calls.length} times, expected ${howMuch}`
+          `Function "${functionName}" was called ${howMuch} times.${suffix}`
         );
       }
       if (!spy.wasCalledWith(...params).nTimes) {
         throw new Error(
-          `Function was not called ${howMuch} times with ${params}`
+          `Function "${functionName}" was not called ${howMuch} times with parameters ${params}${suffix}`
         );
       }
     },
     wasNeverCalled: () => {
       if (spy.calls.length !== 0) {
         throw new Error(
-          `Function was called ${spy.calls.length} times, expected 0`
+          `You expected the function ${functionName} to never be called. ${suffix}`
         );
       }
     },
     wasNeverCalledWith: (...params: any[]) => {
       if (spy.wasCalledWith(...params).atLeastOnce) {
         throw new Error(
-          `Function was called with ${params}, but it should not have been`
+          `Function "${functionName}" was called with parameters ${params}. ${suffix}`
         );
       }
     },
     wasNeverCalledWithSafe: (...params: Params) => {
       if (spy.wasCalledWith(...params).atLeastOnce) {
         throw new Error(
-          `Function was called with ${params}, but it should not have been`
+          `Function "${functionName}" was called with parameters ${params}. ${suffix}`
         );
       }
     },
   };
 }
+
+// TODO: should we rework the wasCalledNTimesWith function API ?


### PR DESCRIPTION
This PR leverages the "rich" error messages built in the previous `verify` feature, and use the calls history part in the `verifyThat` feature.

It also adds tests for the simple wasCalledWith and wasCalledWithSafe helpers.