### PR TITLE
fix: handle anonymous functions & 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vdstack/mockit",
-  "version": "1.5.0-beta.1",
+  "version": "1.5.0",
   "description": "Behaviour mocking library for TypeScript",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/__tests__/common-usecases/testSpecificSubClass.spec.ts
+++ b/src/__tests__/common-usecases/testSpecificSubClass.spec.ts
@@ -1,0 +1,63 @@
+import { Reset, mockFunction, verifyThat, when } from "../../mockit";
+
+/**
+ * This example comes from Clean Code Video series by Robert C. Martin
+ * In particular, its Mocking video, part 2.
+ */
+
+class CowMilker {
+  constructor() {}
+
+  protected pump() {
+    // real implementation
+    throw new Error("Not implemented");
+  }
+
+  protected checkSeal(): boolean {
+    // real implementation
+    throw new Error("Not implemented");
+  }
+
+  public milk() {
+    if (!this.checkSeal()) throw new Error("Seal is broken");
+    this.pump();
+  }
+}
+
+describe("Test specific subclass", () => {
+  let mockPump: () => void;
+  let mockCheckSeal: () => boolean;
+  beforeAll(() => {
+    mockPump = mockFunction(() => {});
+    mockCheckSeal = mockFunction(() => true);
+  });
+
+  beforeEach(() => {
+    Reset.historyOf(mockCheckSeal, mockPump);
+  });
+
+  class TestCowMilker extends CowMilker {
+    protected pump() {
+      return mockPump();
+    }
+    protected checkSeal(): boolean {
+      return mockCheckSeal();
+    }
+  }
+
+  test("Cow milker should check the seal and pump", () => {
+    const milker = new TestCowMilker();
+    when(mockCheckSeal).isCalled.thenReturn(true);
+    milker.milk();
+    verifyThat(mockCheckSeal).wasCalledOnce();
+    verifyThat(mockPump).wasCalledOnce();
+  });
+
+  test("Cow milker should throw error if seal is broken", () => {
+    const milker = new TestCowMilker();
+    when(mockCheckSeal).isCalled.thenReturn(false);
+    expect(() => milker.milk()).toThrowError("Seal is broken");
+    verifyThat(mockCheckSeal).wasCalledOnce();
+    verifyThat(mockPump).wasNeverCalled();
+  });
+});

--- a/src/mockit.ts
+++ b/src/mockit.ts
@@ -32,10 +32,17 @@ export function mock<T>(_original: Class<T>): T {
   return new ConcreteClassMock<T>(_original) as T;
 }
 
+function generateRandomFunctionName() {
+  return `mockedFunction${Math.random().toString().slice(2)}`;
+}
+
 export function mockFunction<T extends (...args: any[]) => any>(
   original: T
 ): T {
-  return FunctionMock(original.name, original) as T;
+  return FunctionMock(
+    original.name.length ? original.name : generateRandomFunctionName(),
+    original
+  ) as T;
 }
 
 export function mockInterface<T>(...functionsToMock: Array<keyof T>): T {


### PR DESCRIPTION
Until now I gave a name to mocks using f.original.name, but it did not work with anonymous functions (duh...).
I added a name generator to handle these cases.

I also added a possible use case of mocks, using an example from a video I watched of the Clean Code video series on mocking.