### PR TITLE
v2 beta: remove zod from dependencies and put it in peerDependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,13 +28,16 @@
     "ts-jest": "^29.0.1",
     "tslib": "^2.4.0",
     "tsup": "^6.5.0",
-    "typescript": "^4.9.0"
+    "typescript": "^4.9.0",
+    "zod": "^3.21.4"
   },
   "lint-staged": {
     "**/*": "prettier --write --ignore-unknown"
   },
   "dependencies": {
-    "node-object-hash": "^2.3.10",
-    "zod": "^3.20.6"
+    "node-object-hash": "^2.3.10"
+  },
+  "peerDependencies": {
+    "zod": "^3.21.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,11 +11,10 @@ specifiers:
   tslib: ^2.4.0
   tsup: ^6.5.0
   typescript: ^4.9.0
-  zod: ^3.20.6
+  zod: ^3.21.4
 
 dependencies:
   node-object-hash: 2.3.10
-  zod: 3.20.6
 
 devDependencies:
   '@changesets/cli': 2.26.0
@@ -27,6 +26,7 @@ devDependencies:
   tslib: 2.4.0
   tsup: 6.5.0_typescript@4.9.4
   typescript: 4.9.4
+  zod: 3.21.4
 
 packages:
 
@@ -4100,6 +4100,6 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /zod/3.20.6:
-    resolution: {integrity: sha512-oyu0m54SGCtzh6EClBVqDDlAYRz4jrVtKwQ7ZnsEmMI9HnzuZFj8QFwAY1M5uniIYACdGvv0PBWPF2kO0aNofA==}
-    dev: false
+  /zod/3.21.4:
+    resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
+    dev: true

--- a/src/__tests__/spy/any/deep.object.spec.ts
+++ b/src/__tests__/spy/any/deep.object.spec.ts
@@ -1,4 +1,5 @@
 import { Mockit } from "../../../mockit";
+import { z } from "zod";
 
 function hello(...args: any[]) {}
 
@@ -7,37 +8,31 @@ describe("Spy: with deep objects and arrays", () => {
     const mock = Mockit.mockFunction(hello);
     const spy = Mockit.spy(mock);
 
-    expect(spy.wasCalledWith({ a: Mockit.any.string }).atLeastOnce).toBe(false);
+    expect(spy.wasCalledWith({ a: z.string() }).atLeastOnce).toBe(false);
     mock({ a: 1 });
-    expect(spy.wasCalledWith({ a: Mockit.any.string }).atLeastOnce).toBe(false);
+    expect(spy.wasCalledWith({ a: z.string() }).atLeastOnce).toBe(false);
     mock({ a: "hello" });
-    expect(spy.wasCalledWith({ a: Mockit.any.string }).atLeastOnce).toBe(true);
+    expect(spy.wasCalledWith({ a: z.string() }).atLeastOnce).toBe(true);
   });
 
   it("should work for level 2 argument", () => {
     const mock = Mockit.mockFunction(hello);
     const spy = Mockit.spy(mock);
 
-    expect(spy.wasCalledWith({ a: { b: Mockit.any.string } }).atLeastOnce).toBe(
-      false
-    );
+    expect(spy.wasCalledWith({ a: { b: z.string() } }).atLeastOnce).toBe(false);
     mock({ a: { b: 1 } });
-    expect(spy.wasCalledWith({ a: { b: Mockit.any.string } }).atLeastOnce).toBe(
-      false
-    );
+    expect(spy.wasCalledWith({ a: { b: z.string() } }).atLeastOnce).toBe(false);
     mock({ a: { b: "hello" } });
-    expect(spy.wasCalledWith({ a: { b: Mockit.any.string } }).atLeastOnce).toBe(
-      true
-    );
+    expect(spy.wasCalledWith({ a: { b: z.string() } }).atLeastOnce).toBe(true);
   });
 
   it("should work for a complex object", () => {
     const object = {
       x: 1,
-      y: { z: { w: { a: Mockit.any.string } } },
+      y: { z: { w: { a: z.string() } } },
       b: true,
-      //   c: [1, 2, Mockit.any.email], // Not working with arrays somehow
-      z: { w: { a: Mockit.any.function } },
+      c: [1, 2, z.string().email()],
+      z: { w: { a: z.function() } },
       list: [
         1,
         2,
@@ -45,7 +40,7 @@ describe("Spy: with deep objects and arrays", () => {
         4,
         {
           x: 1,
-          y: { z: { w: { a: Mockit.any.set } } },
+          y: { z: { w: { a: z.set(z.any()) } } },
         },
       ],
     };
@@ -58,7 +53,7 @@ describe("Spy: with deep objects and arrays", () => {
       x: 1,
       y: { z: { w: { a: "hell" } } },
       b: true,
-      //   c: [1, 2, "not an email"],
+      c: [1, 2, "not an email"],
       z: { w: { a: "not a function" } },
     });
     expect(spy.wasCalledWith(object).atLeastOnce).toBe(false);
@@ -67,6 +62,7 @@ describe("Spy: with deep objects and arrays", () => {
       x: 1,
       y: { z: { w: { a: "hello" } } },
       b: true,
+      c: [1, 2, "vdcd120491@gmail.com"],
       z: { w: { a: () => {} } },
       list: [
         1,
@@ -87,10 +83,10 @@ describe("Spy: with deep objects and arrays", () => {
     const schemas = [
       {
         x: 1,
-        y: { z: { w: { a: Mockit.any.string } } },
+        y: { z: { w: { a: z.string() } } },
       },
       {
-        y: Mockit.any.number,
+        y: z.number(),
       },
     ];
 

--- a/src/mockit.ts
+++ b/src/mockit.ts
@@ -126,23 +126,4 @@ export class Mockit {
   static verify = verify;
   static verifyThat = verifyThat;
   static reset = Reset;
-
-  static get any() {
-    // this is just a port to zod, you can pass zod schemas directly
-    return {
-      string: z.string(),
-      number: z.number(),
-      boolean: z.boolean(),
-      array: z.array(z.any()),
-      object: z.object({}),
-      function: z.function(),
-      uuid: z.string().uuid(),
-      date: z.date(),
-      email: z.string().email(),
-      url: z.string().url(),
-      map: z.map(z.any(), z.any()),
-      set: z.set(z.any()),
-      bigint: z.bigint(),
-    };
-  }
 }


### PR DESCRIPTION
I should have done that way earlier.
This PR transfers the zod dependency from the `dependencies` list to the `peerDependencies`. This means that Mockit will no longer embark zod but will still accept it if the environment has it installed locally.

This will reduce package size as well as dependencies count.