### PR TITLE
v5.0.1: make the value passed type-safe in validates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vdstack/mockit",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Behaviour mocking library for TypeScript",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/behaviours/matchers.fake-compile.spec.ts
+++ b/src/behaviours/matchers.fake-compile.spec.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import { Mock } from "../mocks";
 import {
   anyArray,
@@ -24,6 +25,7 @@ import {
   stringMatching,
   stringStartingWith,
   unsafe,
+  validates,
 } from "./matchers";
 import { when } from "./when";
 /**
@@ -173,4 +175,24 @@ test("typesafe for array containing", () => {
   // Should auto-complete with the correct values
   when(mock).isCalledWith(arrayContaining(["a", "b"]));
   when(mock).isCalledWith(arrayContainingDeep(["a", "b", "c"]));
+});
+
+test("typesafe for validates", () => {
+  function toTest(params: {
+    x: number;
+    y: boolean;
+    z: string;
+  }) {}
+
+  const mock = Mock(toTest);
+
+  when(mock).isCalledWith(validates(( value ) => {
+    return value.x > 0 && value.y && value.z.startsWith("1");
+  }))
+
+  when(mock).isCalledWith(validates(z.object({
+    x: z.number().positive(),
+    y: z.boolean(),
+    z: z.string().startsWith("1"),
+  })))
 });

--- a/src/behaviours/matchers.ts
+++ b/src/behaviours/matchers.ts
@@ -350,7 +350,7 @@ function add(a: any, b: any): any {
  * m.validate((value) => value > 0) // matches 1
  * m.validate((value) => value < 0) // does not match 1
  */
-export function validates<T>(validationFunction: (value: any) => boolean): T;
+export function validates<T>(validationFunction: (value: T) => boolean): T;
 /**
  *
  * @param validationFunction a Zod schema
@@ -363,7 +363,7 @@ export function validates<T>(validationFunction: (value: any) => boolean): T;
  */
 export function validates<T>(validationFunction: ZodSchema<any, any, any>): T;
 export function validates<T>(
-  validationFunction: ((value: any) => boolean) | ZodSchema<any, any, any>
+  validationFunction: ((value: T) => boolean) | ZodSchema<any, any, any>
 ): T {
   if (validationFunction instanceof ZodSchema) {
     return ProxyFactory<T>("isSchema", { schema: validationFunction });


### PR DESCRIPTION
This is a small change that adds type-safety to the value passed to the validation function. This makes writing custom validation functions way easier, and prevent unnoticed changes.

It's potentially breaking if people wrote wrong assertions. Considering the fact that this change is made to notice wrong assertions I decided to pass it as a minor change. Due to 5.0.0 young age (few days) it should not be an issue.