### PR TITLE
v5.0.2: adding m.partial in order to simplify custom responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,36 @@ const response = mockedFunc({
 
 For more information about matchers, see the [Matchers](#matchers) section.
 
+## Returning a partial value
+In a lot of tests, you don't need to provide your mocks with a full object as a response, because you know that only a few keys will be used by the module under test. Mockit provides a way to return a partial object, using the `m.partial` matcher.
+
+TypeScript will help you by providing auto-completion and type-checking, but at the same time will not complain if you don't provide all the keys that would normally be required by the type of the object.
+
+```ts
+type User {
+  // .... a very big type
+}
+
+// You know that only the id property will be used by the module under test.
+
+const mockedFunc = Mock(original);
+when(mockedFunc).isCalled.thenReturn(m.partial({ id: "1" }));
+```
+
+This works with any object, and is functional deep down the object tree.
+
+```ts
+type Response = {
+  user: {
+    id: string;
+    // ... a very big type
+  }
+}
+
+const mockedFunc = Mock(original);
+when(mockedFunc).isCalled.thenReturn(m.partial({ user: { id: "1" } }));
+```
+
 # verifyThat
 
 You can verify how the mock was called using the `verifyThat` API. It provides a semantic way to verify a function mock behaviour.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vdstack/mockit",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Behaviour mocking library for TypeScript",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/behaviours/matchers.fake-compile.spec.ts
+++ b/src/behaviours/matchers.fake-compile.spec.ts
@@ -28,6 +28,7 @@ import {
   validates,
 } from "./matchers";
 import { when } from "./when";
+import { m } from "..";
 /**
  * This test suite is here to test that matchers can take the place of any type of value.
  * We're testing type compilation here, not features. => No assertions needed.
@@ -195,4 +196,19 @@ test("typesafe for validates", () => {
     y: z.boolean(),
     z: z.string().startsWith("1"),
   })))
+});
+
+test("typesafe thenReturn partial", () => {
+  function toTest(): { a: { b: number; c: string}, d: boolean } {
+    return { a: { b: 1, c: "1" }, d: true };
+  }
+
+  const mock = Mock(toTest);
+
+  when(mock).isCalled.thenReturn(m.partial({ a: { b: 1 } }));
+  expect(mock()).toEqual({ a: { b: 1 }});
+
+  when(mock).isCalled.thenReturn({ a: m.partial({ b: 1 }), d: true });
+
+  expect(mock()).toEqual({ a: { b: 1 }, d: true });
 });

--- a/src/behaviours/matchers.ts
+++ b/src/behaviours/matchers.ts
@@ -45,6 +45,20 @@ export const unsafe = <T, U>(value: U | NoInfer<T>): T => {
 };
 
 /**
+ * 
+ * @param value any object
+ * @returns what you pass in, but with the type of the object you want to match
+ * 
+ * @example Your function expects a complex object, but for your test you're only interested in a few keys.
+ * const value: Partial<User> = { id: "1" }
+ * when(mockFunction).isCalled.thenResolve(m.partial(value));
+ */
+export const partial = <T>(value: PartialDeep<NoInfer<T>>): T => {
+  return value as T;
+};
+
+
+/**
  *
  * @param subObject an object that is a subset of the object we want to match
  *
@@ -375,6 +389,7 @@ export function validates<T>(
 export const matchers = {
   isOneOf,
   unsafe,
+  partial,
   objectContaining,
   arrayContaining,
   stringContaining,


### PR DESCRIPTION
This pr adds a new helper: `m.partial`.
It helps for the `thenReturn` and `thenResolve` behaviours setups, by allowing partial objects to be returned/resolved instead of the true original, but still provide type-completion to help build a somewhat valid object for each test.

Very useful when updating from old versions that were not type-safe yet, or when returning very complex objects when the module under test only needs a few keys.