### PR TITLE
adding a bunch of tutorials

### DIFF
--- a/src/argsComparisons/compare.spec.ts
+++ b/src/argsComparisons/compare.spec.ts
@@ -59,6 +59,7 @@ it("should compare deepArrays", () => {
 
   expect(compare(arr1, arr2)).toBe(true);
 
+  // @ts-expect-error
   arr2[1][1][1].push(5);
 
   expect(compare(arr1, arr2)).toBe(false);
@@ -70,6 +71,7 @@ it("should compare objects", () => {
 
   expect(compare(obj1, obj2)).toBe(true);
 
+  // @ts-expect-error
   obj2["key2"] = "value2";
 
   expect(compare(obj1, obj2)).toBe(false);
@@ -81,6 +83,7 @@ it("should compare deepObjects", () => {
 
   expect(compare(obj1, obj2)).toBe(true);
 
+  // @ts-expect-error
   obj2["key"]["key"]["key"]["key2"] = "value2";
 
   expect(compare(obj1, obj2)).toBe(false);

--- a/src/argsComparisons/compare.ts
+++ b/src/argsComparisons/compare.ts
@@ -3,7 +3,7 @@ import { Schema } from "../behaviours/matchers";
 import { containingDeep } from "../behaviours/containing.deep";
 
 // TODO: schemas in maps & sets & arrays
-export function compare(actual: any, expected: any) {
+export function compare(actual: any, expected: any): boolean {
   if (typeof expected === "object" && expected !== null) {
     // fyi, (typeof null) equals "object". I know. #javascript
 
@@ -11,7 +11,7 @@ export function compare(actual: any, expected: any) {
       key.endsWith("mockit__or_operator")
     );
     if (isOROperator) {
-      return expected.options.some((option) => compare(actual, option));
+      return expected.options.some((option: any) => compare(actual, option));
     }
 
     const isInstanceOf = Object.keys(expected).some((key) =>
@@ -40,7 +40,7 @@ export function compare(actual: any, expected: any) {
       key.endsWith("mockit__isOneOf")
     );
     if (isOneOf) {
-      return expected.options.some((option) => compare(actual, option));
+      return expected.options.some((option: unknown) => compare(actual, option));
     }
 
     const isStartsWith = Object.keys(expected).some((key) =>
@@ -119,15 +119,15 @@ export function compare(actual: any, expected: any) {
     if (isContaining) {
       // arrayContaining
       if (Array.isArray(expected.original)) {
-        return expected.original.every((item, index) => {
-          return actual?.some((actualItem) => compare(actualItem, item));
+        return expected.original.every((item: unknown, index: number) => {
+          return actual?.some((actualItem: unknown) => compare(actualItem, item));
         });
       }
 
       // mapContaining
       if (expected.original instanceof Map) {
         return Array.from(
-          ((expected?.original as Map<any, any>) ?? []).entries()
+          ((expected?.original as Map<unknown, unknown>) ?? []).entries()
         ).every(([key, value]) => {
           return compare(actual.get(key), value);
         });
@@ -136,7 +136,7 @@ export function compare(actual: any, expected: any) {
       // setContaining
       if (expected.original instanceof Set) {
         return Array.from(
-          ((expected?.original as Set<any>) ?? []).values()
+          ((expected?.original as Set<unknown>) ?? []).values()
         ).every((value) => {
           return Array.from(actual?.values?.() ?? []).some((actualValue) =>
             compare(actualValue, value)
@@ -169,8 +169,8 @@ export function compare(actual: any, expected: any) {
       }
 
       if (Array.isArray(expected.original)) {
-        return expected.original.every((expectedValue) => {
-          return actual?.some((actualValue) =>
+        return expected.original.every((expectedValue: unknown) => {
+          return actual?.some((actualValue: unknown) =>
             compare(actualValue, containingDeep(expectedValue))
           );
         });
@@ -272,7 +272,7 @@ function containsMockitConstruct(
     | "mockit__isContaining"
     | "mockit__isPartialDeep"
     | "mockit__isContainingDeep"
-) {
+): boolean {
   if (typeof obj !== "object") {
     return false;
   }

--- a/src/behaviours/behaviours.ts
+++ b/src/behaviours/behaviours.ts
@@ -14,7 +14,7 @@ export type Behaviour = typeof Behaviours[keyof typeof Behaviours];
  * This is a discriminated union type that will be used to define behaviours, either
  * by default or for a call with a specific set of arguments.
  */
-export type NewBehaviourParam<T extends (...args) => any> =
+export type NewBehaviourParam<T extends (...args: any[]) => any> =
   | { kind: typeof Behaviours.Throw; error?: any }
   | { kind: typeof Behaviours.Call; callback: (...args: any[]) => any }
   | { kind: typeof Behaviours.Return; returnedValue: any }

--- a/src/examples/mocking-only-one-dependency.spec.ts
+++ b/src/examples/mocking-only-one-dependency.spec.ts
@@ -11,11 +11,13 @@
 import { Mock, when, verifyThat, m } from "..";
 
 interface UserRepository {
-  getUserById(id: number): Promise<{ id: number; email: string; name: string }>;
+  getUserById(
+    id: number
+  ): Promise<{ id: number; email: string; name: string } | undefined>;
 }
 
 interface EmailService {
-  sendEmail(p: {to: string[], content: string}): Promise<{ emailID: number }>;
+  sendEmail(p: { to: string[]; content: string }): Promise<{ emailID: number }>;
 }
 
 async function sendWelcomeEmail(
@@ -30,20 +32,21 @@ async function sendWelcomeEmail(
 
   const { emailID } = await deps.emailService.sendEmail({
     to: [user.email],
-    content: `Welcome ${user.name}!`
+    content: `Welcome ${user.name}!`,
   });
   if (!emailID) throw new Error("Email not sent");
 
   return emailID;
 }
 
+type User = { id: number; email: string; name: string };
 /**
  * For this example I will use an inMemory version of the UserRepository.
  * In your case you would inject a real implementation connected to your DB.
  */
 class DBUserRepository implements UserRepository {
-  private users = [];
-  constructor(users: { id: number; email: string; name: string }[]) {
+  private users: User[] = [];
+  constructor(users: User[]) {
     // in reality you would probably connect to a DB here or receive a transaction of some sort.
     this.users = users;
   }
@@ -86,7 +89,7 @@ test("it should send an email if the user exists and the mail ID", async () => {
   verifyThat(emailService.sendEmail).wasCalledWith(
     m.objectContaining({
       to: [user.email],
-      content: m.anyString() // changing the content won't break the test => it's more resilient to changes in the implementation
+      content: m.anyString(), // changing the content won't break the test => it's more resilient to changes in the implementation
     })
   );
 });

--- a/src/mocks/Mock.ts
+++ b/src/mocks/Mock.ts
@@ -72,6 +72,8 @@ function ProxyMockBase<T>(
         }
         return true;
       }
+
+      return false;
     },
   }) as T;
 }

--- a/src/mocks/mockFunction.ts
+++ b/src/mocks/mockFunction.ts
@@ -167,6 +167,8 @@ export function mockFunction<T extends (...args: any[]) => any>(
         calls.length = 0;
         return true;
       }
+
+      return false;
     },
   });
 }

--- a/src/tutorial/0-what-can-i-mock.spec.ts
+++ b/src/tutorial/0-what-can-i-mock.spec.ts
@@ -1,0 +1,62 @@
+/**
+ * This file displays all the types of mocks that can be created with Mockit.
+ */
+
+// TODO: preserve
+
+import { m } from "..";
+
+test("mocking a function", () => {
+    function funcToMock() {
+        return "Hello, World!";
+    }
+    
+    const mockedFunction = m.Mock(funcToMock);
+    expect(mockedFunction()).toBeUndefined();
+});
+
+test("mocking a type or an interface", () => {
+    type UserRepository = {
+        getUser: (id: number) => string;
+    }
+    
+    const userRepositoryMock = m.Mock<UserRepository>();
+    expect(userRepositoryMock.getUser(1)).toBeUndefined();
+});
+
+test("mocking a class", () => {
+    class UserRepository {
+        getUser(id: number) {
+            return "User 1";
+        }
+    }
+    
+    const userRepositoryMock = m.Mock(UserRepository);
+    expect(userRepositoryMock.getUser(1)).toBeUndefined();
+});
+
+test("mocking an object", () => {
+    const userRepository = {
+        getUser: (id: number) => "User 1"
+    }
+    
+    const userRepositoryMock = m.Mock(userRepository);
+    expect(userRepositoryMock.getUser(1)).toBeUndefined();
+});
+
+test("mocking an abstract class", () => {
+    abstract class UserRepository {
+        abstract getUser(id: number): string;
+        public concreteMethod() {
+            return 2;
+        }
+    }
+    
+    const userRepositoryMock = m.Mock(UserRepository);
+    expect(userRepositoryMock.getUser(1)).toBeUndefined();
+
+    // The concrete method should mocked as well.
+    expect(userRepositoryMock.concreteMethod()).toBeUndefined();
+});
+
+

--- a/src/tutorial/1-default-behaviour.spec.ts
+++ b/src/tutorial/1-default-behaviour.spec.ts
@@ -1,0 +1,56 @@
+/**
+ * This file objective is to show how to setup the default behaviour of a mock.
+ */
+
+import { m } from "..";
+
+type UserRepository = {
+    getUser: (id: number) => string;
+}
+
+const userRepositoryMock = m.Mock<UserRepository>();
+
+/**
+ * By default, all mocked functions will return undefined. This is a trade-off to generate dummy versions of the functions
+ * that pass the compilation and do nothing.
+ */
+test("should return undefined by default", () => {
+    expect(userRepositoryMock.getUser(1)).toBeUndefined();
+});
+
+/**
+ * You can setup how the mock should behave when called with any arguments using the m.when(mockedFunction).isCalled syntax.
+ */
+test("the mock should be controlled by the isCalled syntax", async () => {
+    // You can setup a return value.
+    m.when(userRepositoryMock.getUser).isCalled.thenReturn("222");
+    expect(userRepositoryMock.getUser(1)).toBe("222");
+
+    // You can make the mock throw.
+    m.when(userRepositoryMock.getUser).isCalled.thenThrow(new Error("An error"));
+    expect(() => userRepositoryMock.getUser(1)).toThrow("An error");
+
+    // You can make the mock resolve a value.
+    m.when(userRepositoryMock.getUser).isCalled.thenResolve("222");
+    expect(await userRepositoryMock.getUser(1)).toBe("222");
+
+    // You can make the mock reject a value.
+    m.when(userRepositoryMock.getUser).isCalled.thenReject(new Error("An error"));
+    await expect(userRepositoryMock.getUser(1)).rejects.toThrow("An error");
+
+    // You can make the mock behave like you want.
+    m.when(userRepositoryMock.getUser).isCalled.thenBehaveLike((id) => id);
+    expect(userRepositoryMock.getUser(1)).toBe(1);
+});
+
+/** thenReturn is type-safe, so you can't pass an unsafe value */
+// Uncomment the next line: it will not compile
+// m.when(userRepositoryMock.getUser).isCalled.thenReturn(222);
+
+/**
+ * You can override this type-safety by using the `unsafe` matcher
+*/
+test("should return a number despite the return type of the function", () => {
+    m.when(userRepositoryMock.getUser).isCalled.thenReturn(m.unsafe(222));
+    expect(userRepositoryMock.getUser(1)).toBe(222);
+});

--- a/src/tutorial/2-custom-behaviours-with-exact-values.spec.ts
+++ b/src/tutorial/2-custom-behaviours-with-exact-values.spec.ts
@@ -1,0 +1,27 @@
+/**
+ * This file's objective is to show how to setup the custom behaviours of a mock so that it can 
+ * act specifically for a given set of arguments.
+ */
+
+import { m } from "..";
+
+type UserRepository = {
+    getUser: (id: number) => string;
+}
+
+const userRepositoryMock = m.Mock<UserRepository>();
+
+test("a mock should respond differently for different arguments", () => {
+    /**
+     * For the sake of the demonstration, the mock will throw if the id is not 1 or 2.
+     * If the id is 1, it will return "User 1".
+     * If the id is 2, it will return "User 2".
+     */
+    m.when(userRepositoryMock.getUser).isCalledWith(1).thenReturn("User 1");
+    m.when(userRepositoryMock.getUser).isCalledWith(2).thenReturn("User 2");
+    m.when(userRepositoryMock.getUser).isCalled.thenThrow(new Error("User not found"));
+
+    expect(userRepositoryMock.getUser(1)).toBe("User 1");
+    expect(userRepositoryMock.getUser(2)).toBe("User 2");
+    expect(() => userRepositoryMock.getUser(3)).toThrow("User not found");
+});

--- a/src/tutorial/3-simplified-thenReturn.spec.ts
+++ b/src/tutorial/3-simplified-thenReturn.spec.ts
@@ -1,0 +1,94 @@
+/**
+ * This file demonstrates how to simplify the setup of a mock using a combination of the `thenReturn` and the m.partial helper
+ */
+
+import { m } from "..";
+
+type User = {
+    id: number;
+    name: string;
+    email: string;
+    hobbies: string[];
+    certifications: Array<{ name: string; date: Date;}>
+};
+
+type UserRepository = {
+    getUser: (id: number) => User;
+}
+
+type Mailer = {
+    sendEmail: (to: string, subject: string, body: string) => void;
+}
+
+function sendWelcomeEmail(userId: number, userRepository: UserRepository, mailer: Mailer) {
+    const user = userRepository.getUser(userId);
+    if (!user) {
+        throw new Error("User not found");
+    }
+
+    mailer.sendEmail(user.email, "Welcome!", `Hello ${user.name}, welcome to our platform!`);
+}
+
+/**
+ * BEFORE: you had to provide all the required fields of the User object in the mock setup.
+ * ==> if the User object signature is changed, all tests like this one break.
+ */
+test("you should be able to test the mailer usage without having to mock the entire User object in the UserRepository", () => {
+    const userRepositoryMock = m.Mock<UserRepository>();
+    const mailerMock = m.Mock<Mailer>();
+
+    m.when(userRepositoryMock.getUser).isCalledWith(1).thenReturn({
+        id: 1,
+        email: "user1@example.com",
+        name: "User 1",
+        hobbies: [],
+        certifications: []
+    });
+
+    sendWelcomeEmail(1, userRepositoryMock, mailerMock);
+
+    m.verifyThat(mailerMock.sendEmail).wasCalledWith("user1@example.com", "Welcome!", "Hello User 1, welcome to our platform!");
+});
+
+/**
+ * You should be able to test the mailer usage without having to mock the entire User object in the UserRepository.
+ * Note that the following test is now decoupled from any potential change in the User object, as long as the 
+ * "email" and "name" keys are provided.
+ * 
+ * ==> no need to adapt the test on every new field added to the User object.
+ */
+
+test("you should be able to test the mailer usage without having to mock the entire User object in the UserRepository", () => {
+    const userRepositoryMock = m.Mock<UserRepository>();
+    const mailerMock = m.Mock<Mailer>();
+
+    m.when(userRepositoryMock.getUser).isCalledWith(1).thenReturn(m.partial({
+        email: "user1@example.com",
+        name: "User 1",
+        // It is deeply type-safe: you can provide only the keys you need for nested objects as well
+        // uncomment next line => it will compile
+        // certifications: [{ name: "aeaz" }]
+        
+        // it is still type-safe => it will refuse invalid keys
+        // uncomment the next line to see the error
+        // x: 2
+    }));
+
+    sendWelcomeEmail(1, userRepositoryMock, mailerMock);
+
+    m.verifyThat(mailerMock.sendEmail).wasCalledWith("user1@example.com", "Welcome!", "Hello User 1, welcome to our platform!");
+});
+
+/**
+ * In last resort, you can pass completely unsafe data to the `thenReturn` method.
+ * This is not recommended, as it will not provide any type hinting and will not break on any change.
+ * It can be useful when you're not the owner of the mocked module, and the type signature is insufficiently detailed.
+ * Most common use-case: a function returns either X or undefined, but the type signature says it returns X only.
+*/
+test("you can still pass unsafe data", () => {
+    const userRepositoryMock = m.Mock<UserRepository>();
+    // m.when(userRepositoryMock.getUser).isCalled.thenReturn(undefined);
+    // m.when(userRepositoryMock.getUser).isCalled.thenReturn(m.unsafe(undefined));
+
+    expect(() => sendWelcomeEmail(1, userRepositoryMock, m.Mock<Mailer>())).toThrow("User not found");
+});

--- a/src/tutorial/4-verify-simple-behaviours.spec.ts
+++ b/src/tutorial/4-verify-simple-behaviours.spec.ts
@@ -1,0 +1,35 @@
+/**
+ * This file demonstrates how to verify that a function how many times a function was called.
+ */
+import { m } from "..";
+
+type UserRepository = {
+    getUser: (id: number) => string;
+    saveUser: (data: {
+        id: number;
+        name: string;
+        email: string;
+        hobbies: string[];
+        certifications: Array<{ name: string; date: Date;}>
+    }) => void;
+}
+
+test("you should be able to validate that a function was never called", () => {
+    const userRepositoryMock = m.Mock<UserRepository>();
+    m.verifyThat(userRepositoryMock.saveUser).wasNeverCalled();
+});
+
+test("you should be able to validate that a function was called", () => {
+    const userRepositoryMock = m.Mock<UserRepository>();
+    userRepositoryMock.saveUser({
+        id: 1,
+        name: "User 1",
+        email: "user1@example.com",
+        hobbies: ["Reading", "Writing"],
+        certifications: []
+    });
+
+    m.verifyThat(userRepositoryMock.saveUser).wasCalled();
+    m.verifyThat(userRepositoryMock.saveUser).wasCalledOnce();
+    m.verifyThat(userRepositoryMock.saveUser).wasCalledNTimes(1);
+});

--- a/src/tutorial/5-verify-behaviours-with-arguments.spec.ts
+++ b/src/tutorial/5-verify-behaviours-with-arguments.spec.ts
@@ -1,0 +1,52 @@
+/**
+ * This file demonstrates how to verify that a function was called with a given set of arguments.
+ */
+import { m } from "..";
+
+type UserRepository = {
+    getUser: (id: number) => string;
+    saveUser: (data: {
+        id: number;
+        name: string;
+        email: string;
+        hobbies: string[];
+        certifications: Array<{ name: string; date: Date;}>
+    }) => void;
+}
+
+
+test("you should be able to check that a function was called with specific arguments", () => {
+    const userRepositoryMock = m.Mock<UserRepository>();
+
+    const date = new Date();
+    userRepositoryMock.saveUser({
+        id: 1,
+        name: "User 1",
+        email: "user1@example.com",
+        hobbies: ["Reading", "Writing"],
+        certifications: [{ name: "Cert 1", date }]
+    });
+
+    m.verifyThat(userRepositoryMock.saveUser).wasCalledWith({
+        id: 1,
+        name: "User 1",
+        email: "user1@example.com",
+        hobbies: ["Reading", "Writing"],
+        certifications: [{ name: "Cert 1", date }]
+    });
+
+    m.verifyThat(userRepositoryMock.saveUser).wasNeverCalledWith({
+        id: 2,
+        name: "User 2",
+        email: "user2@example.com",
+        hobbies: ["Reading", "Writing"],
+        certifications: [{ name: "Cert 1", date }]
+    });
+
+    /**
+     * Mockit will provide type hinting for the parameters of the function.
+     */
+    // Uncomment the next line: it will not compile.
+    // m.verifyThat(userRepositoryMock.saveUser).wasCalledWith({ id: 2, name: 0 });
+});
+

--- a/src/tutorial/6-verify-behaviours-with-matchers.spec.ts
+++ b/src/tutorial/6-verify-behaviours-with-matchers.spec.ts
@@ -1,0 +1,171 @@
+/**
+ * This file demonstrates how to use matchers to reduce the complexity of your assertions, make them less brittle by not relying
+ * on exact values, and make your tests more readable.
+ */
+
+import { m } from "..";
+
+type User = {
+    id: number;
+    name: string;
+    email: string;
+    hobbies: string[];
+    certifications: Array<{ name: string; date: Date;}>
+};
+
+type UserRepository = {
+    getUser: (id: number) => User;
+    saveUser: (data: {
+        id: number;
+        name: string;
+        email: string;
+        hobbies: string[];
+        certifications: Array<{ name: string; date: Date;}>
+    }) => void;
+}
+
+function addDataToUser(params: {
+    hobbies: string[];
+    certifications: Array<{ name: string; date: Date }>;
+    id: number;
+}, userRepository: UserRepository) {
+    const user = userRepository.getUser(params.id);
+    if (!user) {
+        throw new Error("User not found");
+    }
+    
+    const newHobbies = Array.from(new Set([...user.hobbies, ...params.hobbies]));
+    const newCerts = Array.from(new Set([...user.certifications, ...params.certifications]));
+
+    userRepository.saveUser({
+        ...user,
+        hobbies: newHobbies,
+        certifications: newCerts
+    });
+}
+
+/**
+ * Here we use the same example as in tutorial 4, and we will gradually simplify the assertions using matchers.
+ */
+
+test("you should be able to check that a function was called with specific arguments", () => {
+    const userRepositoryMock = m.Mock<UserRepository>();
+
+    m.when(userRepositoryMock.getUser).isCalledWith(1).thenReturn({
+        id: 1,
+        name: "User 1",
+        email: "user1@example.com",
+        hobbies: ["Reading"],
+        certifications: []
+    });
+
+    const date = new Date();
+    addDataToUser({
+        id: 1,
+        hobbies: ["Reading", "Writing"],
+        certifications: [{ name: "Cert 1", date }]
+    }, userRepositoryMock);
+
+    /**
+     * Here we verify how the Set helped to uniquely identify the hobbies and certifications.
+     */
+
+    m.verifyThat(userRepositoryMock.saveUser).wasCalledWith({
+        id: 1,
+        name: "User 1",
+        email: "user1@example.com",
+        hobbies: ["Reading", "Writing"],
+        certifications: [{ name: "Cert 1", date }]
+    });
+
+    /**
+     * Let's say that you want to specifically test the hobbies unification logic.
+     * With m.objectContaining you can focus on the relevant part of the object.
+     */
+
+    m.verifyThat(userRepositoryMock.saveUser).wasCalledWith(m.objectContaining({
+        hobbies: ["Reading", "Writing"],
+    }));
+});
+
+/**
+ * Sometimes your test only cares about a very specific part of the object, deep in the hierarchy.
+ * For this you can either compose matchers or use the m.objectContainingDeep matcher.
+ */
+
+test("you should be able to check that a function was called with specific arguments, even if they are deeply nested", () => {
+    const userRepositoryMock = m.Mock<UserRepository>();
+
+    const date = new Date();
+    
+    userRepositoryMock.saveUser({
+        id: 1,
+        name: "User 1",
+        email: "user1@example.com",
+        hobbies: ["Reading"],
+        certifications: [{ name: "Cert 1", date }]
+    });
+
+    m.verifyThat(userRepositoryMock.saveUser).wasCalledWith(m.objectContainingDeep({
+        certifications: [{ date }],
+    }));
+
+    m.verifyThat(userRepositoryMock.saveUser).wasCalledOnceWith(m.objectContaining({
+        certifications: [m.objectContaining({ date })]
+    }));
+
+    m.verifyThat(userRepositoryMock.saveUser).wasCalledWith(m.objectContaining({
+        certifications: m.arrayContaining([m.anyObject()])
+    }))
+});
+
+
+/**
+ * In extreme cases, it can work with APIs like this:
+ */
+
+type DeeplyNested = {
+    x: {
+        y: {
+            z: {
+                w: {
+                    a: {
+                        b: number
+                    }
+                },
+                gg: { m: number }
+            }
+        },
+        e: { f: number },
+    },
+};
+
+type DeeplyNestedArray = Array<Array<Array<number>>>;
+
+function takesDeepObject(data: DeeplyNested) {
+    // does something
+}
+
+function takesDeepArray(data: DeeplyNestedArray) {
+    // does something
+}
+
+test("it should work deeply", () => {
+    const mockedFunc = m.Mock(takesDeepObject);
+    mockedFunc({
+        x: { e: { f: 2 }, y: { z: { gg: {m: 2}, w: { a: {b: 2}}}}}
+    });
+
+    m.verifyThat(mockedFunc).wasCalledWith(m.objectContainingDeep({
+        x: { y: { z: { w: { a: { b: 2 } } } } }
+    }));
+
+    const mockedArrayFunc = m.Mock(takesDeepArray);
+    mockedArrayFunc([[[1, 2], [3, 4], [5, 6]]]);
+
+    m.verifyThat(mockedArrayFunc).wasCalledWith(
+        m.arrayContainingDeep([[[2]]])
+    )
+
+    m.verifyThat(mockedArrayFunc).wasNeverCalledWith([[[666]]])
+});

--- a/src/tutorial/7-custom-behaviour-with-matchers.spec.ts
+++ b/src/tutorial/7-custom-behaviour-with-matchers.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * This file's objective is to showcase how to setup custom behaviours of a mock that will 
+ * match a given set of rules instead of exact values.
+ * These sets of rules are provided by Mockit in the form of matchers.
+ * 
+ * The library provides a wide range of matchers that can be used in various ways, see below.
+ */
+
+import { z } from "zod";
+import { m } from "..";
+
+type UserRepository = {
+    getUser: (id: number) => string;
+}
+
+
+/**
+ * anyXXX matchers are used to match any value of the given category.
+*/
+test("work for any number", () => {
+    const userRepositoryMock = m.Mock<UserRepository>();
+
+    /**
+     * In this example, we're setting up the mock to return "User 1" as long as the id is a number.
+     */
+    m.when(userRepositoryMock.getUser).isCalledWith(m.anyNumber()).thenReturn("User 1");
+    expect(userRepositoryMock.getUser(1)).toBe("User 1");
+    expect(userRepositoryMock.getUser(2)).toBe("User 1");
+    expect(userRepositoryMock.getUser(NaN)).toBeUndefined();
+});
+
+/**
+ * There are a lot of anyXXX matchers available:
+ * - anyString
+ * - anyNumber
+ * - anyBoolean
+ * - anyObject
+ * - anyArray
+ * - anyFunction
+ * - anySet
+ * - anyMap
+ * - anyFalsy
+ * - anyTruthy
+ * - anyNullish
+ */
+
+
+/**
+ * Using the m.validates matcher, you can create your own matcher.
+ */
+test("custom matchers can be created with the validates matcher", () => {
+    const userRepositoryMock = m.Mock<UserRepository>();
+
+    const isEven = (value: number) => value % 2 === 0;
+
+    m.when(userRepositoryMock.getUser).isCalledWith(m.validates(isEven)).thenReturn("Even");
+    m.when(userRepositoryMock.getUser).isCalledWith(m.validates((value) => !isEven(value))).thenReturn("Odd");
+
+    expect(userRepositoryMock.getUser(2)).toBe("Even");
+    expect(userRepositoryMock.getUser(3)).toBe("Odd");
+    expect(userRepositoryMock.getUser(4)).toBe("Even");
+    expect(userRepositoryMock.getUser(5)).toBe("Odd");
+
+    // The validates matcher is type-safe: you will get type-hinting for the parameters of the function
+    // Uncomment the next line: it will not compile because the parseInt function expects a string, not a number
+    // m.when(userRepositoryMock.getUser).isCalledWith(m.validates((value) => parseInt(value, 10) === 2)).thenReturn("Even");
+});
+
+
+test("validates integration with Zod", () => {
+    const userRepositoryMock = m.Mock<UserRepository>();
+
+    const positiveInteger = z.number().int().positive();
+    const negativeInteger = z.number().int().negative();
+
+    m.when(userRepositoryMock.getUser).isCalledWith(m.validates(positiveInteger)).thenReturn("Positive");
+    m.when(userRepositoryMock.getUser).isCalledWith(m.validates(negativeInteger)).thenReturn("Negative");
+
+    expect(userRepositoryMock.getUser(1)).toBe("Positive");
+    expect(userRepositoryMock.getUser(-1)).toBe("Negative");
+
+    // fallback to the default behaviour
+    expect(userRepositoryMock.getUser(0)).toBeUndefined();
+});
+

--- a/src/tutorial/8-spying-a-real-module.spec.ts
+++ b/src/tutorial/8-spying-a-real-module.spec.ts
@@ -1,0 +1,35 @@
+/**
+ * With the thenPreserve behaviour, you can actually preserve the original behaviour of a function in the mock,
+ * while still being able to verify how it was called.
+ */
+
+import { m } from "..";
+
+function getIntegerOddity(id: number) {
+    if (id % 2 === 0) {
+        return "Even";
+    }
+
+    return "Odd";
+}
+
+test("you can preserve the original behaviour of a function", () => {
+    const mockedFunction = m.Mock(getIntegerOddity);
+    m.when(mockedFunction).isCalled.thenPreserve();
+
+    expect(mockedFunction(1)).toBe("Odd");
+    expect(mockedFunction(2)).toBe("Even");
+    expect(mockedFunction(3)).toBe("Odd");
+    expect(mockedFunction(4)).toBe("Even");
+
+    m.verifyThat(mockedFunction).wasCalledWith(1);
+    m.verifyThat(mockedFunction).wasCalledWith(2);
+    m.verifyThat(mockedFunction).wasCalledWith(3);
+    m.verifyThat(mockedFunction).wasCalledWith(4);
+
+    m.verifyThat(mockedFunction).wasNeverCalledWith(5);
+    m.verifyThat(mockedFunction).wasCalledNTimesWith({
+        howMuch: 2,
+        args: [m.validates((value) => value % 2 === 0)]
+    });
+});

--- a/src/tutorial/9-low-level-api_getMockHistory.spec.ts
+++ b/src/tutorial/9-low-level-api_getMockHistory.spec.ts
@@ -1,0 +1,25 @@
+/**
+ * In this file you will learn how to access the raw history of a mock.
+ */
+
+import { m } from "..";
+
+type UserRepository = {
+    getUser: (id: number) => string;
+}
+
+const userRepositoryMock = m.Mock<UserRepository>();
+
+test("I should access the raw history of a mock", () => {
+    userRepositoryMock.getUser(1);
+    userRepositoryMock.getUser(2);
+
+    const history = m.getMockHistory(userRepositoryMock.getUser);
+
+    expect(history.getCalls()[0].args[0]).toBe(1);
+    expect(history.getCalls()[1].args[0]).toBe(2);
+
+    // the calls are type-safe to help you explore the history of the mock
+    // Uncomment the next line: it will not compile because the argument is expected to be a number
+    // history.getCalls()[0].args[0] === "Victor"
+});

--- a/src/tutorial/README.md
+++ b/src/tutorial/README.md
@@ -1,0 +1,1 @@
+This folder contains a set of tutorials that will help you get started with Mockit.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     // enabling declaration (.d.ts) emit
     "declaration": true,
     "noEmit": true,
+    "strict": true,
 
     // optional - in general it's a good practice to decouple declaration files from your actual transpiled JavaScript files
     "declarationDir": "dist/dts",


### PR DESCRIPTION
This PR adds tutorials that will help understand the module bit by bit. It's a complement to the documentation and aims to be more digest.
I already presented it to the R&D @Skillup so I might change a few details but it turned out pretty useful.

I also activated strict mode which caused a few issues that I need to fix before merging.