### PR TITLE
experiment: mock objects generation. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "node-object-hash": "^2.3.10"
   },
   "peerDependencies": {
-    "zod": "^3.21.4"
+    "zod": "^3.21.4",
+    "@anatine/zod-mock": "^3.13.4",
+    "@faker-js/faker": "^8.4.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,6 +1,16 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 dependencies:
+  '@anatine/zod-mock':
+    specifier: ^3.13.4
+    version: 3.13.4(@faker-js/faker@8.4.1)(zod@3.22.4)
+  '@faker-js/faker':
+    specifier: ^8.4.1
+    version: 8.4.1
   node-object-hash:
     specifier: ^2.3.10
     version: 2.3.10
@@ -23,7 +33,7 @@ devDependencies:
     version: 2.8.8
   ts-jest:
     specifier: ^29.1.2
-    version: 29.1.2(jest@29.7.0)(typescript@4.9.5)
+    version: 29.1.2(@babel/core@7.24.0)(esbuild@0.17.19)(jest@29.7.0)(typescript@4.9.5)
   tslib:
     specifier: ^2.6.2
     version: 2.6.2
@@ -46,6 +56,17 @@ packages:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
     dev: true
+
+  /@anatine/zod-mock@3.13.4(@faker-js/faker@8.4.1)(zod@3.22.4):
+    resolution: {integrity: sha512-yO/KeuyYsEDCTcQ+7CiRuY3dnafMHIZUMok6Ci7aERRCTQ+/XmsiPk/RnMx5wlLmWBTmX9kw+PavbMsjM+sAJA==}
+    peerDependencies:
+      '@faker-js/faker': ^7.0.0 || ^8.0.0
+      zod: ^3.21.4
+    dependencies:
+      '@faker-js/faker': 8.4.1
+      randexp: 0.5.3
+      zod: 3.22.4
+    dev: false
 
   /@babel/code-frame@7.23.5:
     resolution: {integrity: sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==}
@@ -761,6 +782,11 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
+
+  /@faker-js/faker@8.4.1:
+    resolution: {integrity: sha512-XQ3cU+Q8Uqmrbf2e0cIC/QN43sTBSC8KF12u29Mb47tWrt2hAgBXSgpZMj4Ao8Uk0iJcU99QsOCaIL8934obCg==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0, npm: '>=6.14.13'}
+    dev: false
 
   /@isaacs/cliui@8.0.2:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -1756,6 +1782,11 @@ packages:
     dependencies:
       path-type: 4.0.0
     dev: true
+
+  /drange@1.1.1:
+    resolution: {integrity: sha512-pYxfDYpued//QpnLIm4Avk7rsNtAtQkUES2cwAYSvD/wd2pKD71gN2Ebj3e7klzXwjocvE8c5vx/1fxwpqmSxA==}
+    engines: {node: '>=4'}
+    dev: false
 
   /eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -3468,6 +3499,14 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /randexp@0.5.3:
+    resolution: {integrity: sha512-U+5l2KrcMNOUPYvazA3h5ekF80FHTUG+87SEAmHZmolh1M+i/WyTCxVzmi+tidIa1tM4BSe8g2Y/D3loWDjj+w==}
+    engines: {node: '>=4'}
+    dependencies:
+      drange: 1.1.1
+      ret: 0.2.2
+    dev: false
+
   /react-is@18.2.0:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
     dev: true
@@ -3563,6 +3602,11 @@ packages:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
     dev: true
+
+  /ret@0.2.2:
+    resolution: {integrity: sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==}
+    engines: {node: '>=4'}
+    dev: false
 
   /reusify@1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
@@ -3975,7 +4019,7 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
-  /ts-jest@29.1.2(jest@29.7.0)(typescript@4.9.5):
+  /ts-jest@29.1.2(@babel/core@7.24.0)(esbuild@0.17.19)(jest@29.7.0)(typescript@4.9.5):
     resolution: {integrity: sha512-br6GJoH/WUX4pu7FbZXuWGKGNDuU7b8Uj77g/Sp7puZV6EXzuByl6JrECvm0MzVzSTkSHWTihsXt+5XYER5b+g==}
     engines: {node: ^16.10.0 || ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -3996,7 +4040,9 @@ packages:
       esbuild:
         optional: true
     dependencies:
+      '@babel/core': 7.24.0
       bs-logger: 0.2.6
+      esbuild: 0.17.19
       fast-json-stable-stringify: 2.1.0
       jest: 29.7.0(@types/node@18.19.21)
       jest-util: 29.7.0
@@ -4365,8 +4411,3 @@ packages:
 
   /zod@3.22.4:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
-    dev: true
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false

--- a/src/__tests__/thenReturn_schemas/anyX-matchers.spec.ts
+++ b/src/__tests__/thenReturn_schemas/anyX-matchers.spec.ts
@@ -1,0 +1,42 @@
+import { m } from "../..";
+
+function hi(): any {};
+
+test("thenReturn should accept a basic a m.any matcher and return a corresponding object", () => {
+    const mock = m.Mock(hi);
+    m.when(mock).isCalled.thenReturn(m.anyArray());
+    expect(Array.isArray(mock())).toBe(true);
+
+    m.when(mock).isCalled.thenReturn(m.anyBoolean());
+    expect(typeof mock()).toBe("boolean");
+
+    m.when(mock).isCalled.thenReturn(m.anyNumber());
+    expect(typeof mock()).toBe("number");
+
+    m.when(mock).isCalled.thenReturn(m.anyObject());
+    expect(typeof mock()).toBe("object");
+
+    m.when(mock).isCalled.thenReturn(m.anyString());
+    expect(typeof mock()).toBe("string");
+
+    m.when(mock).isCalled.thenReturn(m.anyFunction());
+    expect(typeof mock()).toBe("function");
+
+    m.when(mock).isCalled.thenReturn(m.anyMap());
+    expect(mock()).toBeInstanceOf(Map);
+
+    m.when(mock).isCalled.thenReturn(m.anySet());
+    expect(mock()).toBeInstanceOf(Set);
+
+    m.when(mock).isCalled.thenReturn(m.anyNullish());
+    const nullishResult = mock();
+    expect(nullishResult === undefined || nullishResult === null).toBe(true);
+
+    m.when(mock).isCalled.thenReturn(m.anyFalsy());
+    const falsyResult = mock();
+    expect(!falsyResult).toBe(true);
+
+    m.when(mock).isCalled.thenReturn(m.anyTruthy());
+    const truthyResult = mock();
+    expect(!!truthyResult).toBeTruthy();
+});

--- a/src/__tests__/thenReturn_schemas/zod-mock.spec.ts
+++ b/src/__tests__/thenReturn_schemas/zod-mock.spec.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+import { m } from "../..";
+
+function hi(): any {};
+
+test("thenReturn should accept a Zod schema and return a valid object", () => {
+    const schema = z.object({
+        name: z.string(),
+        age: z.number(),
+    });
+    
+    const mock = m.Mock(hi)
+    m.when(mock).isCalled.thenReturn(m.validates(schema));
+    
+    const result = mock();
+    expect(result).toMatchObject({
+        name: expect.any(String),
+        age: expect.any(Number),
+    })
+});
+

--- a/src/behaviours/matcher-proxy-factory.ts
+++ b/src/behaviours/matcher-proxy-factory.ts
@@ -7,6 +7,11 @@ export function ProxyFactory<T>(suffix: string, content: Record<string, any>) {
     {
       get(target, prop) {
         // @ts-expect-error - I don't know how to fix this yet
+        if (target === "mockitSuffix") {
+          return () => suffix;
+        }
+
+        // @ts-expect-error - I don't know how to fix this yet
         return target[prop];
       },
     }

--- a/src/behaviours/matchers.ts
+++ b/src/behaviours/matchers.ts
@@ -331,6 +331,8 @@ export const instanceOf = <T, U>(original: U) => {
   return ProxyFactory<T>("instanceOf", { class: original });
 };
 
+export type anyWhat = "string" | "object" | "number" | "boolean" | "array" | "function" | "nullish" | "falsy" | "truthy" | "map" | "set";
+
 /**
  *
  * @param regexp a regular expression that the string should match
@@ -427,3 +429,4 @@ export type PartialDeep<T> = T extends (...args: any[]) => any
 export type PartialDeepObject<ObjectType extends object> = {
   [KeyType in keyof ObjectType]?: PartialDeep<ObjectType[KeyType]>;
 };
+


### PR DESCRIPTION
This PR adds a new feature: returning/resolving values corresponding to validation and anyXXX matchers instead of specific values. The objective is:
- to speed-up writing tests with categories of values (which matchers are).
- to accept zod schemas, which can help mock APIs thanks to their related validation schemas. 

It works like this:

**For matchers of anyXXX format**, you can pass them in **thenReturn/thenResolve**, and it will generate a value that would pass this matcher in assertions.
```ts
const mock = m.Mock(hi);
m.when(mock).isCalled.thenReturn(m.anyArray());

mock(); // an array
```

**For zod schemas**, you can pass them as well in their dedicated matcher (**m.validates**). To make this works you will need to install two dependencies: 

`npm install zod @faker-js/faker @anatine/zod-mock`

zod-mock is a package that will generate a valid value for a given zod schema. It requires faker (hence the second dependency).
These dependencies are peerDependencies of Mockit: this specific feature won't work if you didn't create it.

```ts
test("thenReturn should accept a Zod schema and return a valid object", () => {
    // In a real world scenario, you will import this schema from the module under test.
    const schema = z.object({
        name: z.string(),
        age: z.number(),
    });
    
    const mock = m.Mock(hi)
    m.when(mock).isCalled.thenReturn(m.validates(schema));
    
    const result = mock();
    expect(result).toMatchObject({
        name: expect.any(String),
        age: expect.any(Number),
    })
});
```

## Thoughs
Honestly I'm not sure if this is really useful, considering the fact that people could just install zod-mock (which they will need to do since I'm not planning on bundling it with Mockit), and could then just call `thenReturn(generateMock(schema))`.

### Todo
- [ ] Make it work on thenResolve
- [ ] remove coupling between anyXXX matchers and zod-mock.
- [ ] decide if this is actually a useful addition.