### PR TITLE
6.0.0-beta-2: enhancement & refacto: complete rewrite of the module's core "compare" function to display detailed reports.

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -6,7 +6,12 @@
       "Bash(find:*)",
       "Bash(cat:*)",
       "Bash(npx tsc:*)",
-      "Bash(npm test:*)"
+      "Bash(npm test:*)",
+      "Bash(ls:*)",
+      "Bash(git show-branch:*)",
+      "WebFetch(domain:www.npmjs.com)",
+      "Bash(pnpm lint:*)",
+      "Bash(pnpm build:*)"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -11,7 +11,8 @@
       "Bash(git show-branch:*)",
       "WebFetch(domain:www.npmjs.com)",
       "Bash(pnpm lint:*)",
-      "Bash(pnpm build:*)"
+      "Bash(pnpm build:*)",
+      "Bash(gh pr view:*)"
     ]
   }
 }

--- a/docs/COMPARE-V2-TECHNICAL.md
+++ b/docs/COMPARE-V2-TECHNICAL.md
@@ -1,0 +1,255 @@
+# Compare V2 - Documentation Technique
+
+## Vue d'ensemble
+
+Compare V2 est une réécriture complète de la fonction `compare` de mockit. Elle remplace l'ancienne implémentation récursive par une architecture modulaire avec :
+- Détection des références circulaires
+- Gestion `undefined` = clé absente
+- Messages d'erreur détaillés avec chemins et diffs visuels
+
+## Architecture des dossiers
+
+```
+src/argsComparisons/
+├── compare.ts                    # Point d'entrée (wrapper rétrocompatible)
+└── compare-v2/
+    ├── index.ts                  # Fonction principale compare()
+    ├── types.ts                  # Tous les types TypeScript
+    ├── context.ts                # Gestion du contexte de comparaison
+    ├── result.ts                 # Builders pour créer les résultats
+    ├── comparators/              # Comparaison par type de valeur
+    │   ├── index.ts              # Dispatcher principal
+    │   ├── primitive-comparator.ts
+    │   ├── object-comparator.ts
+    │   ├── array-comparator.ts
+    │   ├── map-comparator.ts
+    │   └── set-comparator.ts
+    ├── matchers/                 # Handlers pour les matchers mockit
+    │   ├── index.ts              # Détection + dispatcher
+    │   ├── any-matcher.ts        # anyString(), anyNumber(), etc.
+    │   ├── containing-matcher.ts # objectContaining(), arrayContaining(), etc.
+    │   ├── containing-deep-matcher.ts
+    │   ├── validate-matcher.ts   # validates() avec Zod ou fonction custom
+    │   ├── or-matcher.ts         # or(), isOneOf()
+    │   ├── string-matcher.ts     # stringStartingWith(), stringMatching(), etc.
+    │   └── instance-of-matcher.ts
+    └── formatters/               # Formatage des erreurs
+        ├── index.ts              # Dispatcher principal
+        ├── structured-formatter.ts  # Rapport texte chemin par chemin
+        ├── visual-formatter.ts      # Diff visuel avec jest-diff
+        └── matcher-plugin.ts        # Plugin pretty-format pour les matchers
+```
+
+## Types principaux
+
+### `CompareResult`
+Le résultat d'une comparaison :
+```typescript
+interface CompareResult {
+  success: boolean;
+  mismatches: MismatchInfo[];  // Liste des différences trouvées
+}
+```
+
+### `MismatchInfo`
+Décrit une différence :
+```typescript
+interface MismatchInfo {
+  path: Path;           // Chemin structuré: [{ type: "property", key: "user" }, { type: "index", index: 0 }]
+  pathString: string;   // Chemin lisible: "user[0].name"
+  actual: unknown;      // Valeur reçue
+  expected: unknown;    // Valeur attendue
+  kind: MismatchKind;   // Type: "value_mismatch", "type_mismatch", "missing_property", etc.
+  message: string;      // Message humain
+}
+```
+
+### `CompareContext`
+Contexte interne passé pendant la comparaison :
+```typescript
+interface CompareContext {
+  options: CompareOptions;
+  path: Path;                      // Chemin actuel dans l'arbre
+  visitedActual: WeakSet<object>;  // Pour détecter les cycles
+  visitedExpected: WeakSet<object>;
+  depth: number;                   // Profondeur actuelle
+}
+```
+
+### `CompareOptions`
+Options de comparaison :
+```typescript
+interface CompareOptions {
+  treatUndefinedAsAbsent: boolean;  // true = { a: 1 } == { a: 1, b: undefined }
+  maxDepth: number;                 // Limite de profondeur (défaut: 100)
+  collectAllMismatches: boolean;    // true = collecter toutes les erreurs
+}
+```
+
+## Flux de comparaison
+
+```
+compare(actual, expected)
+    │
+    ├─ createContext()           # Initialise WeakSets, path=[], depth=0
+    │
+    └─ compareValues(actual, expected, context)
+         │
+         ├─ detectMatcher(expected)
+         │   │
+         │   ├─ Si matcher trouvé → dispatchToMatcherHandler()
+         │   │   (any-matcher, containing-matcher, etc.)
+         │   │
+         │   └─ Si pas matcher mais contient des matchers imbriqués
+         │       → compareObjectWithMatchers() (récursion contrôlée)
+         │
+         └─ Si pas de matcher → dispatchToComparator()
+             │
+             ├─ Vérifie références circulaires (WeakSet)
+             ├─ Vérifie profondeur max
+             │
+             └─ Route vers le bon comparator:
+                 - primitive-comparator (null, string, number, boolean, etc.)
+                 - object-comparator (plain objects)
+                 - array-comparator
+                 - map-comparator
+                 - set-comparator
+```
+
+## Détection des matchers
+
+Les matchers mockit sont des objets avec une clé `mockit__*` :
+```typescript
+// anyString() crée:
+{ "mockit__any": true, what: "string" }
+
+// objectContaining({ a: 1 }) crée:
+{ "mockit__isContaining": true, original: { a: 1 } }
+```
+
+La fonction `detectMatcher()` cherche ces clés et retourne un `MatcherInfo` avec le type et le payload.
+
+## Comparaison d'objets
+
+Le `object-comparator` fait une comparaison **stricte** :
+1. Toutes les clés de `expected` doivent exister dans `actual` avec les bonnes valeurs
+2. `actual` ne doit PAS avoir de clés supplémentaires (sinon = `extra_property` error)
+3. Si `treatUndefinedAsAbsent: true`, les clés avec valeur `undefined` sont ignorées des deux côtés
+
+C'est différent de `objectContaining()` qui fait du partial matching.
+
+## Gestion des références circulaires
+
+Utilise deux `WeakSet` :
+- `visitedActual` : objets déjà visités côté actual
+- `visitedExpected` : objets déjà visités côté expected
+
+Avant de descendre dans un objet, on vérifie s'il a déjà été visité. Si oui, on considère que c'est OK (on évite la boucle infinie).
+
+## Formatters
+
+### structured-formatter
+Génère un rapport texte chemin par chemin :
+```
+Found 2 mismatch(es):
+
+1. [Value Mismatch] at user.name
+   Expected "John", got "Jane"
+   Expected: "John"
+   Actual:   "Jane"
+
+2. [Type Mismatch] at user.age
+   Expected type "number", got "string"
+```
+
+### visual-formatter
+Génère un diff visuel style git en combinant :
+- `pretty-format` pour sérialiser les valeurs (avec notre plugin pour les matchers)
+- `jest-diff` (`diffStringsUnified`) pour créer le diff
+
+```
+- Expected  - 1
++ Received  + 1
+
+  Object {
+-   "name": "John",
++   "name": "Jane",
+    "age": 25,
+  }
+```
+
+### matcher-plugin
+Plugin `pretty-format` qui permet d'afficher les matchers de façon lisible dans le diff visuel.
+
+Sans le plugin :
+```
+Object {
+    "mockit__any": true,
+    "what": "string",
+}
+```
+
+Avec le plugin :
+```
+anyString()
+```
+
+Le plugin détecte les objets avec une clé `mockit__*` et les sérialise en appelant la fonction de formatage appropriée.
+
+## Intégration avec verifyThat
+
+### API simplifiée
+
+```typescript
+// Par défaut : montre les 3 closest calls avec diff
+verifyThat(mock).wasCalledWith(args);
+
+// Mode verbose : montre tous les calls sans troncature
+verifyThat(mock, { verbose: true }).wasCalledWith(args);
+```
+
+### Comportement par défaut
+
+Quand `wasCalledWith()` échoue :
+1. Compare chaque call avec les arguments attendus via `compareDetailed()`
+2. Trie les calls par nombre de mismatches (closest first)
+3. Affiche les 3 plus proches avec leur diff structuré + visuel
+
+### Closest Call
+
+Quand plusieurs calls existent, on identifie le plus proche en comptant les mismatches :
+```
+Cherche: wasCalledWith("John", 25)
+Call 1: ("Jane", 30)  → 2 mismatches
+Call 2: ("John", 30)  → 1 mismatch  ← closest
+Call 3: ("Bob", 42)   → 2 mismatches
+```
+
+## Exemple de message d'erreur
+
+```
+Function was not called with expected parameters.
+
+Expected: (anyString())
+
+Closest call(s):
+
+--- Call 1 (1 difference(s)) ---
+Arguments: (12345)
+
+Found 1 mismatch(es):
+
+1. [Matcher Failed] at [0]
+  Expected anyString(), got 12345 (number)
+  Expected: anyString()
+  Actual:   12345
+
+Visual diff:
+- Expected  - 1
++ Received  + 1
+
+  [
+-   anyString(),
++   12345,
+  ]
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vdstack/mockit",
-  "version": "6.0.0-beta.1",
+  "version": "6.0.0-beta.2",
   "description": "Behaviour mocking library for TypeScript",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@types/node": "^18.19.21",
     "jest": "^29.7.0",
     "prettier": "^2.8.8",
+    "pretty-format": "^30.2.0",
     "ts-jest": "^29.1.2",
     "tslib": "^2.6.2",
     "tsup": "^6.7.0",
@@ -35,6 +36,7 @@
     "**/*": "prettier --write --ignore-unknown"
   },
   "dependencies": {
+    "jest-diff": "^30.2.0",
     "node-object-hash": "^2.3.10"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,6 +1,9 @@
 lockfileVersion: '6.0'
 
 dependencies:
+  jest-diff:
+    specifier: ^30.2.0
+    version: 30.2.0
   node-object-hash:
     specifier: ^2.3.10
     version: 2.3.10
@@ -21,6 +24,9 @@ devDependencies:
   prettier:
     specifier: ^2.8.8
     version: 2.8.8
+  pretty-format:
+    specifier: ^30.2.0
+    version: 30.2.0
   ts-jest:
     specifier: ^29.1.2
     version: 29.1.2(jest@29.7.0)(typescript@4.9.5)
@@ -845,6 +851,11 @@ packages:
       - ts-node
     dev: true
 
+  /@jest/diff-sequences@30.0.1:
+    resolution: {integrity: sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+    dev: false
+
   /@jest/environment@29.7.0:
     resolution: {integrity: sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -883,6 +894,11 @@ packages:
       jest-mock: 29.7.0
       jest-util: 29.7.0
     dev: true
+
+  /@jest/get-type@30.1.0:
+    resolution: {integrity: sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+    dev: false
 
   /@jest/globals@29.7.0:
     resolution: {integrity: sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==}
@@ -939,6 +955,12 @@ packages:
     dependencies:
       '@sinclair/typebox': 0.27.8
     dev: true
+
+  /@jest/schemas@30.0.5:
+    resolution: {integrity: sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+    dependencies:
+      '@sinclair/typebox': 0.34.47
 
   /@jest/source-map@29.6.3:
     resolution: {integrity: sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==}
@@ -1086,6 +1108,9 @@ packages:
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
     dev: true
 
+  /@sinclair/typebox@0.34.47:
+    resolution: {integrity: sha512-ZGIBQ+XDvO5JQku9wmwtabcVTHJsgSWAHYtVuM9pBNNR5E88v6Jcj/llpmsjivig5X8A8HHOb4/mbEKPS5EvAw==}
+
   /@sinonjs/commons@3.0.1:
     resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
     dependencies:
@@ -1226,12 +1251,10 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       color-convert: 2.0.1
-    dev: true
 
   /ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
-    dev: true
 
   /ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
@@ -1515,7 +1538,6 @@ packages:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
-    dev: true
 
   /char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
@@ -1592,7 +1614,6 @@ packages:
     engines: {node: '>=7.0.0'}
     dependencies:
       color-name: 1.1.4
-    dev: true
 
   /color-name@1.1.3:
     resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
@@ -1600,7 +1621,6 @@ packages:
 
   /color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-    dev: true
 
   /commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -2211,7 +2231,6 @@ packages:
   /has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
-    dev: true
 
   /has-property-descriptors@1.0.2:
     resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
@@ -2655,6 +2674,16 @@ packages:
       jest-get-type: 29.6.3
       pretty-format: 29.7.0
     dev: true
+
+  /jest-diff@30.2.0:
+    resolution: {integrity: sha512-dQHFo3Pt4/NLlG5z4PxZ/3yZTZ1C7s9hveiOj+GCN+uT109NC2QgsoVZsVOAvbJ3RgKkvyLGXZV9+piDpWbm6A==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+    dependencies:
+      '@jest/diff-sequences': 30.0.1
+      '@jest/get-type': 30.1.0
+      chalk: 4.1.2
+      pretty-format: 30.2.0
+    dev: false
 
   /jest-docblock@29.7.0:
     resolution: {integrity: sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==}
@@ -3438,6 +3467,14 @@ packages:
       react-is: 18.2.0
     dev: true
 
+  /pretty-format@30.2.0:
+    resolution: {integrity: sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+    dependencies:
+      '@jest/schemas': 30.0.5
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
+
   /prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
@@ -3471,6 +3508,9 @@ packages:
   /react-is@18.2.0:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
     dev: true
+
+  /react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
   /read-pkg-up@7.0.1:
     resolution: {integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==}
@@ -3892,7 +3932,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       has-flag: 4.0.0
-    dev: true
 
   /supports-color@8.1.1:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}

--- a/src/__tests__/compare-v2/error-messages-demo.spec.ts
+++ b/src/__tests__/compare-v2/error-messages-demo.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * Demo file to showcase the new error messages
+ *
+ * To see the error messages, temporarily remove `.skip` and run:
+ * pnpm test src/__tests__/compare-v2/error-messages-demo.spec.ts
+ *
+ * These tests are designed to FAIL to show the error messages.
+ */
+
+import { Mock } from "../../mocks";
+import { verifyThat } from "../../assertions/verifyThat";
+import { m } from "../..";
+
+describe("Error Messages Demo", () => {
+  it("placeholder to keep the file in CI", () => {
+    expect(true).toBe(true);
+  });
+
+  // 1. Function never called
+  it.skip("Demo: Function never called", () => {
+    const mock = Mock((name: string) => `Hello ${name}`);
+    verifyThat(mock).wasCalledWith("John");
+  });
+
+  // 2. Value mismatch - shows closest calls with diff
+  it.skip("Demo: Value mismatch with multiple calls", () => {
+    const mock = Mock((name: string, age: number) => `${name} is ${age}`);
+    mock("Jane", 30);
+    mock("Bob", 42);
+    mock("John", 99); // Closest to expected
+
+    verifyThat(mock).wasCalledWith("John", 25);
+  });
+
+  // 3. Object mismatch - nested diff
+  it.skip("Demo: Object mismatch", () => {
+    const mock = Mock((user: { name: string; address: { city: string } }) => user);
+    mock({ name: "Victor", address: { city: "Paris" } });
+
+    verifyThat(mock).wasCalledWith({
+      name: "Victor",
+      address: { city: "Lyon" },
+    });
+  });
+
+  // 4. Matcher failed
+  it.skip("Demo: Matcher failed", () => {
+    const mock = Mock((id: string | number) => id);
+    mock(12345);
+
+    verifyThat(mock).wasCalledWith(m.anyString());
+  });
+
+  // 5. Verbose mode - shows all calls
+  it.skip("Demo: Verbose mode", () => {
+    const mock = Mock((x: number) => x * 2);
+    mock(1);
+    mock(2);
+    mock(3);
+    mock(4);
+    mock(5);
+
+    verifyThat(mock, { verbose: true }).wasCalledWith(100);
+  });
+});

--- a/src/argsComparisons/compare-v2/comparators/array-comparator.ts
+++ b/src/argsComparisons/compare-v2/comparators/array-comparator.ts
@@ -1,0 +1,75 @@
+/**
+ * Array comparator
+ */
+
+import { CompareContext, CompareResult } from "../types";
+import {
+  createSuccessResult,
+  createFailureResult,
+  mergeResults,
+} from "../result";
+import { pushPath } from "../context";
+
+// Forward declaration - will be set by index.ts to avoid circular imports
+let compareValuesDelegate: (
+  actual: unknown,
+  expected: unknown,
+  context: CompareContext
+) => CompareResult;
+
+export function setCompareValuesDelegate(
+  fn: (
+    actual: unknown,
+    expected: unknown,
+    context: CompareContext
+  ) => CompareResult
+): void {
+  compareValuesDelegate = fn;
+}
+
+/**
+ * Compare two arrays
+ */
+export function compareArrays(
+  actual: unknown[],
+  expected: unknown[],
+  context: CompareContext
+): CompareResult {
+  // Length check for exact matching (not containing)
+  if (actual.length !== expected.length) {
+    return createFailureResult(context, {
+      kind: "array_length",
+      message: `Expected array of length ${expected.length}, got length ${actual.length}`,
+      actual: actual.length,
+      expected: expected.length,
+    });
+  }
+
+  // Compare element by element
+  const results: CompareResult[] = [];
+
+  for (let i = 0; i < expected.length; i++) {
+    const itemContext = pushPath(context, { type: "index", index: i });
+    const result = compareValuesDelegate(actual[i], expected[i], itemContext);
+
+    if (!result.success) {
+      if (!context.options.collectAllMismatches) {
+        return result;
+      }
+      results.push(result);
+    }
+  }
+
+  if (results.length > 0) {
+    return mergeResults(results);
+  }
+
+  return createSuccessResult();
+}
+
+/**
+ * Check if a value is an array
+ */
+export function isArray(value: unknown): value is unknown[] {
+  return Array.isArray(value);
+}

--- a/src/argsComparisons/compare-v2/comparators/index.ts
+++ b/src/argsComparisons/compare-v2/comparators/index.ts
@@ -1,0 +1,233 @@
+/**
+ * Comparator dispatcher
+ * Routes comparison to the appropriate comparator based on value types
+ */
+
+import { CompareContext, CompareResult } from "../types";
+import { createSuccessResult, createFailureResult, Mismatches } from "../result";
+import {
+  isCircularActual,
+  isCircularExpected,
+  isMaxDepthExceeded,
+  markVisited,
+} from "../context";
+
+import { comparePrimitives, isPrimitive } from "./primitive-comparator";
+import {
+  compareArrays,
+  isArray,
+  setCompareValuesDelegate as setArrayDelegate,
+} from "./array-comparator";
+import {
+  compareObjects,
+  isPlainObject,
+  setCompareValuesDelegate as setObjectDelegate,
+} from "./object-comparator";
+import {
+  compareMaps,
+  isMap,
+  setCompareValuesDelegate as setMapDelegate,
+} from "./map-comparator";
+import {
+  compareSets,
+  isSet,
+  setCompareValuesDelegate as setSetDelegate,
+} from "./set-comparator";
+
+// Set up the delegates to avoid circular imports
+// This will be called by the main compare function
+export function initializeComparators(
+  compareValues: (
+    actual: unknown,
+    expected: unknown,
+    context: CompareContext
+  ) => CompareResult
+): void {
+  setArrayDelegate(compareValues);
+  setObjectDelegate(compareValues);
+  setMapDelegate(compareValues);
+  setSetDelegate(compareValues);
+}
+
+/**
+ * Dispatch to the appropriate comparator based on value types
+ * This handles non-matcher values
+ */
+export function dispatchToComparator(
+  actual: unknown,
+  expected: unknown,
+  context: CompareContext
+): CompareResult {
+  // Check for max depth
+  if (isMaxDepthExceeded(context)) {
+    return Mismatches.maxDepthExceeded(context);
+  }
+
+  // Handle null/undefined explicitly
+  if (expected === null) {
+    if (actual === null) {
+      return createSuccessResult();
+    }
+    return createFailureResult(context, {
+      kind: "value_mismatch",
+      message: `Expected null, got ${typeof actual}`,
+      actual,
+      expected,
+    });
+  }
+
+  if (expected === undefined) {
+    if (actual === undefined) {
+      return createSuccessResult();
+    }
+    // With treatUndefinedAsAbsent, this case should be handled upstream
+    return createFailureResult(context, {
+      kind: "value_mismatch",
+      message: `Expected undefined, got ${typeof actual}`,
+      actual,
+      expected,
+    });
+  }
+
+  // Primitives (excluding null/undefined handled above)
+  if (isPrimitive(expected)) {
+    return comparePrimitives(actual, expected, context);
+  }
+
+  // From here, expected is an object type
+
+  // Type mismatch: actual is not an object
+  if (typeof actual !== "object" || actual === null) {
+    return createFailureResult(context, {
+      kind: "type_mismatch",
+      message: `Expected ${getTypeName(expected)}, got ${actual === null ? "null" : typeof actual}`,
+      actual,
+      expected,
+    });
+  }
+
+  // Check for circular references
+  if (
+    isCircularActual(context, actual as object) ||
+    isCircularExpected(context, expected as object)
+  ) {
+    // Circular reference found - consider them equal if both are circular
+    // at the same depth point
+    return createSuccessResult();
+  }
+
+  // Mark as visited for circular reference tracking
+  const visitedContext = markVisited(
+    context,
+    actual as object,
+    expected as object
+  );
+
+  // Arrays
+  if (isArray(expected)) {
+    if (!isArray(actual)) {
+      return createFailureResult(context, {
+        kind: "type_mismatch",
+        message: `Expected array, got ${getTypeName(actual)}`,
+        actual,
+        expected,
+      });
+    }
+    return compareArrays(actual, expected, visitedContext);
+  }
+
+  // Maps
+  if (isMap(expected)) {
+    if (!isMap(actual)) {
+      return createFailureResult(context, {
+        kind: "type_mismatch",
+        message: `Expected Map, got ${getTypeName(actual)}`,
+        actual,
+        expected,
+      });
+    }
+    return compareMaps(actual, expected, visitedContext);
+  }
+
+  // Sets
+  if (isSet(expected)) {
+    if (!isSet(actual)) {
+      return createFailureResult(context, {
+        kind: "type_mismatch",
+        message: `Expected Set, got ${getTypeName(actual)}`,
+        actual,
+        expected,
+      });
+    }
+    return compareSets(actual, expected, visitedContext);
+  }
+
+  // Plain objects
+  if (isPlainObject(expected)) {
+    if (!isPlainObject(actual)) {
+      return createFailureResult(context, {
+        kind: "type_mismatch",
+        message: `Expected plain object, got ${getTypeName(actual)}`,
+        actual,
+        expected,
+      });
+    }
+    return compareObjects(actual, expected, visitedContext);
+  }
+
+  // Other object types (Date, RegExp, custom classes, etc.)
+  // Fall back to strict equality
+  if (actual === expected) {
+    return createSuccessResult();
+  }
+
+  // Try to handle special cases
+  if (expected instanceof Date && actual instanceof Date) {
+    if (expected.getTime() === actual.getTime()) {
+      return createSuccessResult();
+    }
+    return createFailureResult(context, {
+      kind: "value_mismatch",
+      message: `Expected Date ${expected.toISOString()}, got ${actual.toISOString()}`,
+      actual,
+      expected,
+    });
+  }
+
+  if (expected instanceof RegExp && actual instanceof RegExp) {
+    if (expected.toString() === actual.toString()) {
+      return createSuccessResult();
+    }
+    return createFailureResult(context, {
+      kind: "value_mismatch",
+      message: `Expected RegExp ${expected}, got ${actual}`,
+      actual,
+      expected,
+    });
+  }
+
+  // Default: not equal
+  return createFailureResult(context, {
+    kind: "value_mismatch",
+    message: `Values are not equal`,
+    actual,
+    expected,
+  });
+}
+
+/**
+ * Get a human-readable type name for a value
+ */
+function getTypeName(value: unknown): string {
+  if (value === null) return "null";
+  if (value === undefined) return "undefined";
+  if (Array.isArray(value)) return "array";
+  if (value instanceof Map) return "Map";
+  if (value instanceof Set) return "Set";
+  if (value instanceof Date) return "Date";
+  if (value instanceof RegExp) return "RegExp";
+  return typeof value;
+}
+
+// Re-export type checks for use in other modules
+export { isPrimitive, isArray, isPlainObject, isMap, isSet };

--- a/src/argsComparisons/compare-v2/comparators/map-comparator.ts
+++ b/src/argsComparisons/compare-v2/comparators/map-comparator.ts
@@ -1,0 +1,92 @@
+/**
+ * Map comparator
+ */
+
+import { CompareContext, CompareResult, formatValue } from "../types";
+import {
+  createSuccessResult,
+  createFailureResult,
+  mergeResults,
+} from "../result";
+import { pushPath } from "../context";
+
+// Forward declaration - will be set by index.ts to avoid circular imports
+let compareValuesDelegate: (
+  actual: unknown,
+  expected: unknown,
+  context: CompareContext
+) => CompareResult;
+
+export function setCompareValuesDelegate(
+  fn: (
+    actual: unknown,
+    expected: unknown,
+    context: CompareContext
+  ) => CompareResult
+): void {
+  compareValuesDelegate = fn;
+}
+
+/**
+ * Compare two Maps
+ */
+export function compareMaps(
+  actual: Map<unknown, unknown>,
+  expected: Map<unknown, unknown>,
+  context: CompareContext
+): CompareResult {
+  // Size check for exact matching
+  if (actual.size !== expected.size) {
+    return createFailureResult(context, {
+      kind: "value_mismatch",
+      message: `Expected Map of size ${expected.size}, got size ${actual.size}`,
+      actual: actual.size,
+      expected: expected.size,
+    });
+  }
+
+  const results: CompareResult[] = [];
+
+  // Check all expected entries exist in actual with matching values
+  for (const [key, expectedValue] of expected.entries()) {
+    const keyContext = pushPath(context, { type: "mapKey", key });
+
+    if (!actual.has(key)) {
+      const result = createFailureResult(keyContext, {
+        kind: "map_key_missing",
+        message: `Map is missing key ${formatValue(key)}`,
+        actual: undefined,
+        expected: expectedValue,
+      });
+
+      if (!context.options.collectAllMismatches) {
+        return result;
+      }
+      results.push(result);
+      continue;
+    }
+
+    const actualValue = actual.get(key);
+    const result = compareValuesDelegate(actualValue, expectedValue, keyContext);
+
+    if (!result.success) {
+      if (!context.options.collectAllMismatches) {
+        return result;
+      }
+      results.push(result);
+    }
+  }
+
+  if (results.length > 0) {
+    return mergeResults(results);
+  }
+
+  return createSuccessResult();
+}
+
+/**
+ * Check if a value is a Map
+ */
+export function isMap(value: unknown): value is Map<unknown, unknown> {
+  return value instanceof Map;
+}

--- a/src/argsComparisons/compare-v2/comparators/object-comparator.ts
+++ b/src/argsComparisons/compare-v2/comparators/object-comparator.ts
@@ -1,0 +1,153 @@
+/**
+ * Object comparator with undefined handling
+ */
+
+import { CompareContext, CompareResult } from "../types";
+import {
+  createSuccessResult,
+  createFailureResult,
+  mergeResults,
+} from "../result";
+import { pushPath } from "../context";
+
+// Forward declaration - will be set by index.ts to avoid circular imports
+let compareValuesDelegate: (
+  actual: unknown,
+  expected: unknown,
+  context: CompareContext
+) => CompareResult;
+
+export function setCompareValuesDelegate(
+  fn: (
+    actual: unknown,
+    expected: unknown,
+    context: CompareContext
+  ) => CompareResult
+): void {
+  compareValuesDelegate = fn;
+}
+
+/**
+ * Compare two plain objects
+ */
+export function compareObjects(
+  actual: Record<string, unknown>,
+  expected: Record<string, unknown>,
+  context: CompareContext
+): CompareResult {
+  const { treatUndefinedAsAbsent } = context.options;
+
+  // Get keys from both objects
+  const actualKeys = new Set(Object.keys(actual));
+  const expectedKeys = new Set(Object.keys(expected));
+
+  // Filter out undefined keys if treatUndefinedAsAbsent is true
+  const effectiveActualKeys = treatUndefinedAsAbsent
+    ? filterUndefinedKeys(actual, actualKeys)
+    : actualKeys;
+
+  const effectiveExpectedKeys = treatUndefinedAsAbsent
+    ? filterUndefinedKeys(expected, expectedKeys)
+    : expectedKeys;
+
+  const results: CompareResult[] = [];
+
+  // Check all expected keys exist in actual with matching values
+  for (const key of effectiveExpectedKeys) {
+    const keyContext = pushPath(context, { type: "property", key });
+
+    // Check if key exists in actual (considering undefined handling)
+    const actualHasKey = treatUndefinedAsAbsent
+      ? effectiveActualKeys.has(key)
+      : actualKeys.has(key);
+
+    if (!actualHasKey) {
+      const result = createFailureResult(keyContext, {
+        kind: "missing_property",
+        message: `Missing property "${key}"`,
+        actual: undefined,
+        expected: expected[key],
+      });
+
+      if (!context.options.collectAllMismatches) {
+        return result;
+      }
+      results.push(result);
+      continue;
+    }
+
+    // Compare values
+    const result = compareValuesDelegate(actual[key], expected[key], keyContext);
+
+    if (!result.success) {
+      if (!context.options.collectAllMismatches) {
+        return result;
+      }
+      results.push(result);
+    }
+  }
+
+  // Check for extra keys in actual
+  // For strict comparison (not using objectContaining), actual should not have extra keys
+  for (const key of effectiveActualKeys) {
+    if (!effectiveExpectedKeys.has(key)) {
+      const keyContext = pushPath(context, { type: "property", key });
+      const result = createFailureResult(keyContext, {
+        kind: "extra_property",
+        message: `Unexpected property "${key}"`,
+        actual: actual[key],
+        expected: undefined,
+      });
+
+      if (!context.options.collectAllMismatches) {
+        return result;
+      }
+      results.push(result);
+    }
+  }
+
+  if (results.length > 0) {
+    return mergeResults(results);
+  }
+
+  return createSuccessResult();
+}
+
+/**
+ * Filter out keys that have undefined values
+ */
+function filterUndefinedKeys(
+  obj: Record<string, unknown>,
+  keys: Set<string>
+): Set<string> {
+  const result = new Set<string>();
+  for (const key of keys) {
+    if (obj[key] !== undefined) {
+      result.add(key);
+    }
+  }
+  return result;
+}
+
+/**
+ * Check if a value is a plain object (not array, Map, Set, etc.)
+ */
+export function isPlainObject(
+  value: unknown
+): value is Record<string, unknown> {
+  if (value === null || typeof value !== "object") {
+    return false;
+  }
+  if (Array.isArray(value)) {
+    return false;
+  }
+  if (value instanceof Map || value instanceof Set) {
+    return false;
+  }
+  if (value instanceof Date || value instanceof RegExp) {
+    return false;
+  }
+  // Check for plain object prototype
+  const proto = Object.getPrototypeOf(value);
+  return proto === null || proto === Object.prototype;
+}

--- a/src/argsComparisons/compare-v2/comparators/primitive-comparator.ts
+++ b/src/argsComparisons/compare-v2/comparators/primitive-comparator.ts
@@ -1,0 +1,66 @@
+/**
+ * Primitive value comparator
+ * Handles: null, undefined, number, string, boolean, symbol, bigint, function
+ */
+
+import { CompareContext, CompareResult, formatValue } from "../types";
+import { createSuccessResult, createFailureResult } from "../result";
+
+/**
+ * Compare two primitive values
+ */
+export function comparePrimitives(
+  actual: unknown,
+  expected: unknown,
+  context: CompareContext
+): CompareResult {
+  // Exact equality for primitives
+  if (actual === expected) {
+    return createSuccessResult();
+  }
+
+  // Special case: NaN comparison (NaN !== NaN in JS)
+  if (
+    typeof actual === "number" &&
+    typeof expected === "number" &&
+    isNaN(actual) &&
+    isNaN(expected)
+  ) {
+    return createSuccessResult();
+  }
+
+  // Type mismatch
+  if (typeof actual !== typeof expected) {
+    return createFailureResult(context, {
+      kind: "type_mismatch",
+      message: `Expected type "${typeof expected}", got "${typeof actual}"`,
+      actual,
+      expected,
+    });
+  }
+
+  // Same type but different value
+  return createFailureResult(context, {
+    kind: "value_mismatch",
+    message: `Expected ${formatValue(expected)}, got ${formatValue(actual)}`,
+    actual,
+    expected,
+  });
+}
+
+/**
+ * Check if a value is a primitive (not an object or array)
+ */
+export function isPrimitive(value: unknown): boolean {
+  if (value === null) return true;
+  const type = typeof value;
+  return (
+    type === "undefined" ||
+    type === "boolean" ||
+    type === "number" ||
+    type === "string" ||
+    type === "symbol" ||
+    type === "bigint" ||
+    type === "function"
+  );
+}

--- a/src/argsComparisons/compare-v2/comparators/set-comparator.ts
+++ b/src/argsComparisons/compare-v2/comparators/set-comparator.ts
@@ -1,0 +1,95 @@
+/**
+ * Set comparator
+ */
+
+import { CompareContext, CompareResult, formatValue } from "../types";
+import {
+  createSuccessResult,
+  createFailureResult,
+  mergeResults,
+} from "../result";
+import { pushPath } from "../context";
+
+// Forward declaration - will be set by index.ts to avoid circular imports
+let compareValuesDelegate: (
+  actual: unknown,
+  expected: unknown,
+  context: CompareContext
+) => CompareResult;
+
+export function setCompareValuesDelegate(
+  fn: (
+    actual: unknown,
+    expected: unknown,
+    context: CompareContext
+  ) => CompareResult
+): void {
+  compareValuesDelegate = fn;
+}
+
+/**
+ * Compare two Sets
+ */
+export function compareSets(
+  actual: Set<unknown>,
+  expected: Set<unknown>,
+  context: CompareContext
+): CompareResult {
+  // Size check for exact matching
+  if (actual.size !== expected.size) {
+    return createFailureResult(context, {
+      kind: "value_mismatch",
+      message: `Expected Set of size ${expected.size}, got size ${actual.size}`,
+      actual: actual.size,
+      expected: expected.size,
+    });
+  }
+
+  const results: CompareResult[] = [];
+  const actualArray = Array.from(actual.values());
+
+  // For each expected value, find a matching actual value
+  for (const expectedValue of expected.values()) {
+    const valueContext = pushPath(context, {
+      type: "setValue",
+      value: expectedValue,
+    });
+
+    // Try to find a match in actual
+    const found = actualArray.some((actualValue) => {
+      const result = compareValuesDelegate(
+        actualValue,
+        expectedValue,
+        valueContext
+      );
+      return result.success;
+    });
+
+    if (!found) {
+      const result = createFailureResult(valueContext, {
+        kind: "set_value_missing",
+        message: `Set is missing value ${formatValue(expectedValue)}`,
+        actual: undefined,
+        expected: expectedValue,
+      });
+
+      if (!context.options.collectAllMismatches) {
+        return result;
+      }
+      results.push(result);
+    }
+  }
+
+  if (results.length > 0) {
+    return mergeResults(results);
+  }
+
+  return createSuccessResult();
+}
+
+/**
+ * Check if a value is a Set
+ */
+export function isSet(value: unknown): value is Set<unknown> {
+  return value instanceof Set;
+}

--- a/src/argsComparisons/compare-v2/context.ts
+++ b/src/argsComparisons/compare-v2/context.ts
@@ -1,0 +1,114 @@
+/**
+ * Context management for compare-v2
+ */
+
+import {
+  CompareContext,
+  CompareOptions,
+  DEFAULT_OPTIONS,
+  Path,
+  PathSegment,
+} from "./types";
+
+/**
+ * Create a new compare context with the given options
+ */
+export function createContext(
+  options?: Partial<CompareOptions>
+): CompareContext {
+  return {
+    options: { ...DEFAULT_OPTIONS, ...options },
+    path: [],
+    visitedActual: new WeakSet(),
+    visitedExpected: new WeakSet(),
+    depth: 0,
+  };
+}
+
+/**
+ * Create a new context with an extended path
+ */
+export function pushPath(
+  context: CompareContext,
+  segment: PathSegment
+): CompareContext {
+  return {
+    ...context,
+    path: [...context.path, segment],
+    depth: context.depth + 1,
+  };
+}
+
+/**
+ * Check if an object has already been visited (circular reference detection)
+ */
+export function isCircularActual(
+  context: CompareContext,
+  obj: object
+): boolean {
+  return context.visitedActual.has(obj);
+}
+
+/**
+ * Check if an expected object has already been visited
+ */
+export function isCircularExpected(
+  context: CompareContext,
+  obj: object
+): boolean {
+  return context.visitedExpected.has(obj);
+}
+
+/**
+ * Mark objects as visited and return the context
+ * Note: We mutate the WeakSets since they're shared through the comparison tree
+ * This is intentional - we want to detect cycles across all branches
+ */
+export function markVisited(
+  context: CompareContext,
+  actual: object | null,
+  expected: object | null
+): CompareContext {
+  if (actual !== null) {
+    context.visitedActual.add(actual);
+  }
+  if (expected !== null) {
+    context.visitedExpected.add(expected);
+  }
+
+  return context;
+}
+
+/**
+ * Check if we've exceeded the maximum depth
+ */
+export function isMaxDepthExceeded(context: CompareContext): boolean {
+  return context.depth >= context.options.maxDepth;
+}
+
+/**
+ * Get the current path as a string
+ */
+export function getCurrentPathString(context: CompareContext): string {
+  return formatPathToString(context.path);
+}
+
+/**
+ * Format a path array to a string
+ */
+function formatPathToString(path: Path): string {
+  if (path.length === 0) return "<root>";
+
+  return path.reduce((acc, segment) => {
+    switch (segment.type) {
+      case "property":
+        return acc ? `${acc}.${segment.key}` : segment.key;
+      case "index":
+        return `${acc}[${segment.index}]`;
+      case "mapKey":
+        return `${acc}.get(${JSON.stringify(segment.key)})`;
+      case "setValue":
+        return `${acc}.has(${JSON.stringify(segment.value)})`;
+    }
+  }, "");
+}

--- a/src/argsComparisons/compare-v2/formatters/index.ts
+++ b/src/argsComparisons/compare-v2/formatters/index.ts
@@ -1,0 +1,48 @@
+/**
+ * Formatter dispatcher
+ */
+
+import { CompareResult } from "../types";
+import { formatVisualDiff, VisualDiffOptions } from "./visual-formatter";
+import { formatStructuredDiff, StructuredFormatOptions } from "./structured-formatter";
+
+export interface FormatOptions {
+  /** Show everything without truncation */
+  verbose?: boolean;
+}
+
+/**
+ * Format a CompareResult for display
+ * Always shows structured diff + visual diff
+ */
+export function formatResult(
+  result: CompareResult,
+  expected: unknown,
+  actual: unknown,
+  options: FormatOptions = {}
+): string {
+  const { verbose = false } = options;
+
+  if (result.success) {
+    return "Values are equal";
+  }
+
+  const parts: string[] = [];
+
+  // Structured diff (path by path)
+  parts.push(formatStructuredDiff(result, {
+    includeValues: true,
+    maxMismatches: verbose ? 100 : 10,
+  }));
+
+  // Visual diff (always shown now)
+  parts.push("");
+  parts.push("Visual diff:");
+  parts.push(formatVisualDiff(expected, actual));
+
+  return parts.join("\n");
+}
+
+// Re-export individual formatters
+export { formatVisualDiff } from "./visual-formatter";
+export { formatStructuredDiff } from "./structured-formatter";

--- a/src/argsComparisons/compare-v2/formatters/matcher-plugin.ts
+++ b/src/argsComparisons/compare-v2/formatters/matcher-plugin.ts
@@ -1,0 +1,84 @@
+/**
+ * Pretty-format plugin for mockit matchers
+ *
+ * This plugin allows jest-diff to display matchers like anyString()
+ * instead of { "mockit__any": true, "what": "string" }
+ */
+
+import type { NewPlugin } from "pretty-format";
+
+/**
+ * Check if a value is a mockit matcher
+ */
+function isMockitMatcher(val: unknown): val is Record<string, unknown> {
+  if (typeof val !== "object" || val === null) return false;
+  return Object.keys(val).some((k) => k.startsWith("mockit__"));
+}
+
+/**
+ * Format a matcher for display in diffs
+ */
+function formatMatcherForDiff(matcher: Record<string, unknown>): string {
+  const matcherKey = Object.keys(matcher).find((k) => k.startsWith("mockit__"));
+  if (!matcherKey) return "[Matcher]";
+
+  const type = matcherKey.replace("mockit__", "");
+
+  switch (type) {
+    case "any":
+      return `any${capitalize(matcher.what as string)}()`;
+
+    case "isContaining":
+      if (typeof matcher.original === "string")
+        return `stringContaining("${matcher.original}")`;
+      if (Array.isArray(matcher.original)) return `arrayContaining([...])`;
+      if (matcher.original instanceof Map) return `mapContaining(Map)`;
+      if (matcher.original instanceof Set) return `setContaining(Set)`;
+      return `objectContaining({...})`;
+
+    case "isContainingDeep":
+      if (Array.isArray(matcher.original)) return `arrayContainingDeep([...])`;
+      if (matcher.original instanceof Map) return `mapContainingDeep(Map)`;
+      if (matcher.original instanceof Set) return `setContainingDeep(Set)`;
+      return `objectContainingDeep({...})`;
+
+    case "isSchema":
+      return `validates(ZodSchema)`;
+
+    case "validate":
+      return `validates(fn)`;
+
+    case "or_operator":
+      return `or(...)`;
+
+    case "isOneOf":
+      return `isOneOf([...])`;
+
+    case "instanceOf":
+      return `instanceOf(${(matcher.class as { name: string })?.name || "Class"})`;
+
+    case "startsWith":
+      return `stringStartingWith("${matcher.original}")`;
+
+    case "endsWith":
+      return `stringEndingWith("${matcher.original}")`;
+
+    case "matchesRegex":
+      return `stringMatching(${matcher.regexp})`;
+
+    default:
+      return `[Matcher: ${type}]`;
+  }
+}
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+/**
+ * Pretty-format plugin for mockit matchers
+ */
+export const mockitMatcherPlugin: NewPlugin = {
+  test: isMockitMatcher,
+  serialize: (val: unknown) => formatMatcherForDiff(val as Record<string, unknown>),
+};

--- a/src/argsComparisons/compare-v2/formatters/structured-formatter.ts
+++ b/src/argsComparisons/compare-v2/formatters/structured-formatter.ts
@@ -1,0 +1,128 @@
+/**
+ * Structured diff formatter - path-by-path report
+ */
+
+import { CompareResult, MismatchInfo, formatValue } from "../types";
+
+export interface StructuredFormatOptions {
+  /** Include actual and expected values in output */
+  includeValues?: boolean;
+  /** Maximum number of mismatches to show */
+  maxMismatches?: number;
+  /** Indentation string */
+  indent?: string;
+}
+
+/**
+ * Format a CompareResult as a structured text report
+ */
+export function formatStructuredDiff(
+  result: CompareResult,
+  options: StructuredFormatOptions = {}
+): string {
+  if (result.success) {
+    return "Values are equal";
+  }
+
+  const {
+    includeValues = true,
+    maxMismatches = 10,
+    indent = "  ",
+  } = options;
+
+  const lines: string[] = [];
+  const mismatches = result.mismatches.slice(0, maxMismatches);
+
+  lines.push(`Found ${result.mismatches.length} mismatch(es):`);
+  lines.push("");
+
+  for (let i = 0; i < mismatches.length; i++) {
+    const mismatch = mismatches[i];
+    lines.push(formatMismatch(mismatch, includeValues, indent, i + 1));
+  }
+
+  if (result.mismatches.length > maxMismatches) {
+    lines.push(
+      `... and ${result.mismatches.length - maxMismatches} more mismatch(es)`
+    );
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Format a single mismatch
+ */
+function formatMismatch(
+  mismatch: MismatchInfo,
+  includeValues: boolean,
+  indent: string,
+  index: number
+): string {
+  const lines: string[] = [];
+
+  // Header with path and kind
+  const kindLabel = formatKind(mismatch.kind);
+  lines.push(`${index}. [${kindLabel}] at ${mismatch.pathString}`);
+
+  // Message
+  lines.push(`${indent}${mismatch.message}`);
+
+  // Values if requested
+  if (includeValues) {
+    lines.push(`${indent}Expected: ${formatValue(mismatch.expected)}`);
+    lines.push(`${indent}Actual:   ${formatValue(mismatch.actual)}`);
+  }
+
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+/**
+ * Format mismatch kind as a human-readable label
+ */
+function formatKind(kind: MismatchInfo["kind"]): string {
+  switch (kind) {
+    case "type_mismatch":
+      return "Type Mismatch";
+    case "value_mismatch":
+      return "Value Mismatch";
+    case "missing_property":
+      return "Missing Property";
+    case "extra_property":
+      return "Extra Property";
+    case "array_length":
+      return "Array Length";
+    case "matcher_failed":
+      return "Matcher Failed";
+    case "circular_reference":
+      return "Circular Reference";
+    case "max_depth_exceeded":
+      return "Max Depth";
+    case "map_key_missing":
+      return "Map Key Missing";
+    case "set_value_missing":
+      return "Set Value Missing";
+    default:
+      return "Mismatch";
+  }
+}
+
+/**
+ * Format a summary line for quick overview
+ */
+export function formatSummary(result: CompareResult): string {
+  if (result.success) {
+    return "Match: Values are equal";
+  }
+
+  const count = result.mismatches.length;
+  const first = result.mismatches[0];
+
+  if (count === 1) {
+    return `No match: ${first.message} at ${first.pathString}`;
+  }
+
+  return `No match: ${count} differences found. First: ${first.message} at ${first.pathString}`;
+}

--- a/src/argsComparisons/compare-v2/formatters/visual-formatter.ts
+++ b/src/argsComparisons/compare-v2/formatters/visual-formatter.ts
@@ -1,0 +1,74 @@
+/**
+ * Visual diff formatter using jest-diff + pretty-format
+ */
+
+import { diffStringsUnified } from "jest-diff";
+import { format } from "pretty-format";
+import { CompareResult } from "../types";
+import { mockitMatcherPlugin } from "./matcher-plugin";
+
+export interface VisualDiffOptions {
+  /** Label for expected value */
+  aAnnotation?: string;
+  /** Label for actual value */
+  bAnnotation?: string;
+  /** Show full object context */
+  expand?: boolean;
+  /** Number of context lines to show */
+  contextLines?: number;
+}
+
+/**
+ * Generate a visual diff between expected and actual values
+ */
+export function formatVisualDiff(
+  expected: unknown,
+  actual: unknown,
+  options: VisualDiffOptions = {}
+): string {
+  const {
+    aAnnotation = "Expected",
+    bAnnotation = "Received",
+    expand = true,
+    contextLines = 5,
+  } = options;
+
+  // Serialize with pretty-format using our matcher plugin
+  const formatOptions = {
+    plugins: [mockitMatcherPlugin],
+    printBasicPrototype: false,
+  };
+
+  const expectedStr = format(expected, formatOptions);
+  const actualStr = format(actual, formatOptions);
+
+  // Diff the serialized strings
+  const result = diffStringsUnified(expectedStr, actualStr, {
+    aAnnotation,
+    bAnnotation,
+    expand,
+    contextLines,
+    includeChangeCounts: true,
+    aIndicator: "-",
+    bIndicator: "+",
+  });
+
+  return result;
+}
+
+/**
+ * Generate visual diff from a CompareResult
+ */
+export function formatResultVisualDiff(
+  result: CompareResult,
+  expected: unknown,
+  actual: unknown
+): string {
+  if (result.success) {
+    return "Values are equal";
+  }
+
+  const diffOutput = formatVisualDiff(expected, actual);
+
+  return `${diffOutput}`;
+}

--- a/src/argsComparisons/compare-v2/index.ts
+++ b/src/argsComparisons/compare-v2/index.ts
@@ -1,0 +1,292 @@
+/**
+ * Compare V2 - Main entry point
+ *
+ * A rewritten comparison function with:
+ * - Circular reference handling
+ * - undefined = absent key support
+ * - Rich error messages with path tracking
+ */
+
+import {
+  CompareContext,
+  CompareOptions,
+  CompareResult,
+  DEFAULT_OPTIONS,
+} from "./types";
+import { createContext, pushPath } from "./context";
+import { createSuccessResult } from "./result";
+import {
+  dispatchToComparator,
+  initializeComparators,
+  isArray,
+  isMap,
+  isPlainObject,
+  isSet,
+} from "./comparators";
+import {
+  detectMatcher,
+  dispatchToMatcherHandler,
+  containsMockitConstruct,
+  initializeMatchers,
+} from "./matchers";
+
+// Initialize the delegates
+let initialized = false;
+
+function ensureInitialized(): void {
+  if (!initialized) {
+    initializeComparators(compareValues);
+    initializeMatchers(compareValues);
+    initialized = true;
+  }
+}
+
+/**
+ * Compare two values and return a detailed result
+ *
+ * @param actual The actual value received
+ * @param expected The expected value or matcher
+ * @param options Optional comparison options
+ * @returns CompareResult with success status and mismatch details
+ */
+export function compare(
+  actual: unknown,
+  expected: unknown,
+  options?: Partial<CompareOptions>
+): CompareResult {
+  ensureInitialized();
+  const context = createContext(options);
+  return compareValues(actual, expected, context);
+}
+
+/**
+ * Compare two values for backward compatibility (returns boolean)
+ */
+export function compareBoolean(actual: unknown, expected: unknown): boolean {
+  return compare(actual, expected).success;
+}
+
+/**
+ * Internal comparison function that handles all value types
+ */
+function compareValues(
+  actual: unknown,
+  expected: unknown,
+  context: CompareContext
+): CompareResult {
+  // Check if expected is a matcher
+  const matcherInfo = detectMatcher(expected);
+  if (matcherInfo) {
+    return dispatchToMatcherHandler(actual, matcherInfo, context);
+  }
+
+  // If expected contains matchers nested inside, we need to recurse
+  if (
+    typeof expected === "object" &&
+    expected !== null &&
+    containsMockitConstruct(expected)
+  ) {
+    return compareObjectWithMatchers(actual, expected, context);
+  }
+
+  // No matchers - use regular comparison
+  return dispatchToComparator(actual, expected, context);
+}
+
+/**
+ * Compare objects that contain matchers nested inside
+ */
+function compareObjectWithMatchers(
+  actual: unknown,
+  expected: object,
+  context: CompareContext
+): CompareResult {
+  // Arrays
+  if (isArray(expected)) {
+    if (!isArray(actual)) {
+      return {
+        success: false,
+        mismatches: [
+          {
+            path: context.path,
+            pathString: context.path.length === 0 ? "<root>" : formatPathString(context.path),
+            actual,
+            expected,
+            kind: "type_mismatch",
+            message: `Expected array, got ${typeof actual}`,
+          },
+        ],
+      };
+    }
+
+    // Compare element by element
+    for (let i = 0; i < expected.length; i++) {
+      const itemContext = pushPath(context, { type: "index", index: i });
+      const result = compareValues(
+        (actual as unknown[])[i],
+        expected[i],
+        itemContext
+      );
+
+      if (!result.success) {
+        if (!context.options.collectAllMismatches) {
+          return result;
+        }
+        // Collect mismatches if needed
+        return result;
+      }
+    }
+
+    return createSuccessResult();
+  }
+
+  // Maps
+  if (isMap(expected)) {
+    if (!isMap(actual)) {
+      return {
+        success: false,
+        mismatches: [
+          {
+            path: context.path,
+            pathString: formatPathString(context.path),
+            actual,
+            expected,
+            kind: "type_mismatch",
+            message: `Expected Map, got ${typeof actual}`,
+          },
+        ],
+      };
+    }
+
+    for (const [key, expectedValue] of expected.entries()) {
+      const keyContext = pushPath(context, { type: "mapKey", key });
+      const result = compareValues(
+        (actual as Map<unknown, unknown>).get(key),
+        expectedValue,
+        keyContext
+      );
+
+      if (!result.success) {
+        return result;
+      }
+    }
+
+    return createSuccessResult();
+  }
+
+  // Sets
+  if (isSet(expected)) {
+    if (!isSet(actual)) {
+      return {
+        success: false,
+        mismatches: [
+          {
+            path: context.path,
+            pathString: formatPathString(context.path),
+            actual,
+            expected,
+            kind: "type_mismatch",
+            message: `Expected Set, got ${typeof actual}`,
+          },
+        ],
+      };
+    }
+
+    const actualArray = Array.from((actual as Set<unknown>).values());
+
+    for (const expectedValue of expected.values()) {
+      const found = actualArray.some((actualValue) => {
+        const result = compareValues(actualValue, expectedValue, context);
+        return result.success;
+      });
+
+      if (!found) {
+        return {
+          success: false,
+          mismatches: [
+            {
+              path: context.path,
+              pathString: formatPathString(context.path),
+              actual,
+              expected: expectedValue,
+              kind: "set_value_missing",
+              message: "Set is missing expected value",
+            },
+          ],
+        };
+      }
+    }
+
+    return createSuccessResult();
+  }
+
+  // Plain objects
+  if (isPlainObject(expected)) {
+    if (!isPlainObject(actual)) {
+      return {
+        success: false,
+        mismatches: [
+          {
+            path: context.path,
+            pathString: formatPathString(context.path),
+            actual,
+            expected,
+            kind: "type_mismatch",
+            message: `Expected object, got ${typeof actual}`,
+          },
+        ],
+      };
+    }
+
+    for (const key of Object.keys(expected)) {
+      const keyContext = pushPath(context, { type: "property", key });
+      const result = compareValues(
+        (actual as Record<string, unknown>)[key],
+        (expected as Record<string, unknown>)[key],
+        keyContext
+      );
+
+      if (!result.success) {
+        return result;
+      }
+    }
+
+    return createSuccessResult();
+  }
+
+  // Fallback
+  return dispatchToComparator(actual, expected, context);
+}
+
+/**
+ * Format path to string
+ */
+function formatPathString(path: CompareContext["path"]): string {
+  if (path.length === 0) return "<root>";
+
+  return path.reduce((acc, segment) => {
+    switch (segment.type) {
+      case "property":
+        return acc ? `${acc}.${segment.key}` : segment.key;
+      case "index":
+        return `${acc}[${segment.index}]`;
+      case "mapKey":
+        return `${acc}.get(${JSON.stringify(segment.key)})`;
+      case "setValue":
+        return `${acc}.has(${JSON.stringify(segment.value)})`;
+    }
+  }, "");
+}
+
+// Re-export types
+export type {
+  CompareResult,
+  CompareOptions,
+  CompareContext,
+  MismatchInfo,
+  MismatchKind,
+  Path,
+  PathSegment,
+} from "./types";
+
+export { DEFAULT_OPTIONS, formatPath, formatValue } from "./types";

--- a/src/argsComparisons/compare-v2/matchers/any-matcher.ts
+++ b/src/argsComparisons/compare-v2/matchers/any-matcher.ts
@@ -1,0 +1,115 @@
+/**
+ * Handler for anyX() matchers
+ * anyNumber, anyString, anyBoolean, anyObject, anyArray, anyFunction,
+ * anyNullish, anyMap, anySet, anyFalsy, anyTruthy
+ */
+
+import { CompareContext, CompareResult, MatcherInfo, formatValue } from "../types";
+import { createSuccessResult, createFailureResult } from "../result";
+
+/**
+ * Handle any* matcher comparison
+ */
+export function handleAnyMatcher(
+  actual: unknown,
+  matcherInfo: MatcherInfo,
+  context: CompareContext
+): CompareResult {
+  const what = matcherInfo.payload.what as string;
+  let matches: boolean;
+  let description: string;
+
+  switch (what) {
+    case "number":
+      matches = typeof actual === "number" && !isNaN(actual);
+      description = "anyNumber()";
+      break;
+
+    case "string":
+      matches = typeof actual === "string";
+      description = "anyString()";
+      break;
+
+    case "boolean":
+      matches = typeof actual === "boolean";
+      description = "anyBoolean()";
+      break;
+
+    case "object":
+      matches =
+        typeof actual === "object" &&
+        actual !== null &&
+        !Array.isArray(actual) &&
+        !(actual instanceof Map) &&
+        !(actual instanceof Set);
+      description = "anyObject()";
+      break;
+
+    case "array":
+      matches = Array.isArray(actual);
+      description = "anyArray()";
+      break;
+
+    case "map":
+      matches = actual instanceof Map;
+      description = "anyMap()";
+      break;
+
+    case "set":
+      matches = actual instanceof Set;
+      description = "anySet()";
+      break;
+
+    case "function":
+      matches = typeof actual === "function";
+      description = "anyFunction()";
+      break;
+
+    case "nullish":
+      matches = actual == null;
+      description = "anyNullish()";
+      break;
+
+    case "undefined":
+      matches = actual === undefined;
+      description = "anyUndefined()";
+      break;
+
+    case "falsy":
+      matches = !actual;
+      description = "anyFalsy()";
+      break;
+
+    case "truthy":
+      matches = !!actual;
+      description = "anyTruthy()";
+      break;
+
+    default:
+      matches = false;
+      description = `any${what}()`;
+  }
+
+  if (matches) {
+    return createSuccessResult();
+  }
+
+  return createFailureResult(context, {
+    kind: "matcher_failed",
+    message: `Expected ${description}, got ${formatValue(actual)} (${typeof actual})`,
+    actual,
+    expected: matcherInfo.payload,
+  });
+}
+
+/**
+ * Format the any matcher for display
+ */
+export function formatAnyMatcher(matcherInfo: MatcherInfo): string {
+  const what = matcherInfo.payload.what as string;
+  return `any${capitalize(what)}()`;
+}
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}

--- a/src/argsComparisons/compare-v2/matchers/containing-deep-matcher.ts
+++ b/src/argsComparisons/compare-v2/matchers/containing-deep-matcher.ts
@@ -1,0 +1,210 @@
+/**
+ * Handler for deep containing matchers
+ * objectContainingDeep, arrayContainingDeep, mapContainingDeep, setContainingDeep
+ */
+
+import { CompareContext, CompareResult, MatcherInfo, formatValue } from "../types";
+import { createSuccessResult, createFailureResult } from "../result";
+import { pushPath } from "../context";
+import { containingDeep } from "../../../behaviours/containing.deep";
+
+// Forward declaration - will be set by index.ts to avoid circular imports
+let compareValuesDelegate: (
+  actual: unknown,
+  expected: unknown,
+  context: CompareContext
+) => CompareResult;
+
+export function setCompareValuesDelegate(
+  fn: (
+    actual: unknown,
+    expected: unknown,
+    context: CompareContext
+  ) => CompareResult
+): void {
+  compareValuesDelegate = fn;
+}
+
+/**
+ * Handle containingDeep matcher comparison
+ */
+export function handleContainingDeepMatcher(
+  actual: unknown,
+  matcherInfo: MatcherInfo,
+  context: CompareContext
+): CompareResult {
+  const original = matcherInfo.payload.original;
+
+  // For primitives, compare directly
+  if (typeof original !== "object" || original === null) {
+    return compareValuesDelegate(actual, original, context);
+  }
+
+  // For arrays, each expected item must match some actual item (deep partial)
+  if (Array.isArray(original)) {
+    if (!Array.isArray(actual)) {
+      return createFailureResult(context, {
+        kind: "type_mismatch",
+        message: `Expected array for arrayContainingDeep(), got ${typeof actual}`,
+        actual,
+        expected: matcherInfo.payload,
+      });
+    }
+
+    for (const expectedItem of original) {
+      // Wrap in containingDeep for recursive deep partial matching
+      const deepExpected = wrapInContainingDeep(expectedItem);
+      const found = actual.some((actualItem) => {
+        const result = compareValuesDelegate(actualItem, deepExpected, context);
+        return result.success;
+      });
+
+      if (!found) {
+        return createFailureResult(context, {
+          kind: "matcher_failed",
+          message: `Array does not contain expected item (deep): ${formatValue(expectedItem)}`,
+          actual,
+          expected: matcherInfo.payload,
+        });
+      }
+    }
+
+    return createSuccessResult();
+  }
+
+  // For Maps
+  if (original instanceof Map) {
+    if (!(actual instanceof Map)) {
+      return createFailureResult(context, {
+        kind: "type_mismatch",
+        message: `Expected Map for mapContainingDeep(), got ${typeof actual}`,
+        actual,
+        expected: matcherInfo.payload,
+      });
+    }
+
+    for (const [key, expectedValue] of original.entries()) {
+      const keyContext = pushPath(context, { type: "mapKey", key });
+
+      if (!actual.has(key)) {
+        return createFailureResult(keyContext, {
+          kind: "map_key_missing",
+          message: `Map is missing key ${formatValue(key)}`,
+          actual: undefined,
+          expected: expectedValue,
+        });
+      }
+
+      const actualValue = actual.get(key);
+      const deepExpected = wrapInContainingDeep(expectedValue);
+      const result = compareValuesDelegate(actualValue, deepExpected, keyContext);
+
+      if (!result.success) {
+        return result;
+      }
+    }
+
+    return createSuccessResult();
+  }
+
+  // For Sets
+  if (original instanceof Set) {
+    if (!(actual instanceof Set)) {
+      return createFailureResult(context, {
+        kind: "type_mismatch",
+        message: `Expected Set for setContainingDeep(), got ${typeof actual}`,
+        actual,
+        expected: matcherInfo.payload,
+      });
+    }
+
+    const actualArray = Array.from(actual.values());
+
+    for (const expectedValue of original.values()) {
+      const deepExpected = wrapInContainingDeep(expectedValue);
+      const found = actualArray.some((actualValue) => {
+        const result = compareValuesDelegate(actualValue, deepExpected, context);
+        return result.success;
+      });
+
+      if (!found) {
+        return createFailureResult(context, {
+          kind: "set_value_missing",
+          message: `Set does not contain expected value (deep): ${formatValue(expectedValue)}`,
+          actual,
+          expected: matcherInfo.payload,
+        });
+      }
+    }
+
+    return createSuccessResult();
+  }
+
+  // For objects
+  if (typeof actual !== "object" || actual === null) {
+    return createFailureResult(context, {
+      kind: "type_mismatch",
+      message: `Expected object for objectContainingDeep(), got ${typeof actual}`,
+      actual,
+      expected: matcherInfo.payload,
+    });
+  }
+
+  const actualObj = actual as Record<string, unknown>;
+  const expectedObj = original as Record<string, unknown>;
+
+  for (const key of Object.keys(expectedObj)) {
+    const keyContext = pushPath(context, { type: "property", key });
+    const expectedValue = expectedObj[key];
+    const actualValue = actualObj[key];
+
+    // Wrap nested objects in containingDeep
+    const deepExpected = wrapInContainingDeep(expectedValue);
+    const result = compareValuesDelegate(actualValue, deepExpected, keyContext);
+
+    if (!result.success) {
+      return result;
+    }
+  }
+
+  return createSuccessResult();
+}
+
+/**
+ * Wrap a value in containingDeep if it's an object (and not already a matcher)
+ */
+function wrapInContainingDeep(value: unknown): unknown {
+  if (typeof value !== "object" || value === null) {
+    return value;
+  }
+
+  // Check if already a matcher
+  if (isMatcher(value)) {
+    return value;
+  }
+
+  // Wrap in containingDeep
+  return containingDeep(value);
+}
+
+/**
+ * Check if a value is already a matcher
+ */
+function isMatcher(value: unknown): boolean {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const keys = Object.keys(value);
+  return keys.some((k) => k.startsWith("mockit__"));
+}
+
+/**
+ * Format the containing deep matcher for display
+ */
+export function formatContainingDeepMatcher(matcherInfo: MatcherInfo): string {
+  const original = matcherInfo.payload.original;
+  if (Array.isArray(original)) return `arrayContainingDeep([...])`;
+  if (original instanceof Map) return `mapContainingDeep(Map)`;
+  if (original instanceof Set) return `setContainingDeep(Set)`;
+  return `objectContainingDeep({...})`;
+}

--- a/src/argsComparisons/compare-v2/matchers/containing-matcher.ts
+++ b/src/argsComparisons/compare-v2/matchers/containing-matcher.ts
@@ -1,0 +1,204 @@
+/**
+ * Handler for shallow containing matchers
+ * objectContaining, arrayContaining, mapContaining, setContaining, stringContaining
+ */
+
+import { CompareContext, CompareResult, MatcherInfo, formatValue } from "../types";
+import { createSuccessResult, createFailureResult } from "../result";
+import { pushPath } from "../context";
+
+// Forward declaration - will be set by index.ts to avoid circular imports
+let compareValuesDelegate: (
+  actual: unknown,
+  expected: unknown,
+  context: CompareContext
+) => CompareResult;
+
+export function setCompareValuesDelegate(
+  fn: (
+    actual: unknown,
+    expected: unknown,
+    context: CompareContext
+  ) => CompareResult
+): void {
+  compareValuesDelegate = fn;
+}
+
+/**
+ * Handle containing matcher comparison
+ */
+export function handleContainingMatcher(
+  actual: unknown,
+  matcherInfo: MatcherInfo,
+  context: CompareContext
+): CompareResult {
+  const original = matcherInfo.payload.original;
+
+  // String containing
+  if (typeof original === "string") {
+    if (typeof actual !== "string") {
+      return createFailureResult(context, {
+        kind: "type_mismatch",
+        message: `Expected string for stringContaining(), got ${typeof actual}`,
+        actual,
+        expected: matcherInfo.payload,
+      });
+    }
+
+    if (actual.includes(original)) {
+      return createSuccessResult();
+    }
+
+    return createFailureResult(context, {
+      kind: "matcher_failed",
+      message: `Expected string containing "${original}", got "${actual}"`,
+      actual,
+      expected: matcherInfo.payload,
+    });
+  }
+
+  // Array containing
+  if (Array.isArray(original)) {
+    if (!Array.isArray(actual)) {
+      return createFailureResult(context, {
+        kind: "type_mismatch",
+        message: `Expected array for arrayContaining(), got ${typeof actual}`,
+        actual,
+        expected: matcherInfo.payload,
+      });
+    }
+
+    for (let i = 0; i < original.length; i++) {
+      const expectedItem = original[i];
+      const found = actual.some((actualItem) => {
+        const result = compareValuesDelegate(actualItem, expectedItem, context);
+        return result.success;
+      });
+
+      if (!found) {
+        return createFailureResult(context, {
+          kind: "matcher_failed",
+          message: `Array does not contain expected item ${formatValue(expectedItem)}`,
+          actual,
+          expected: matcherInfo.payload,
+        });
+      }
+    }
+
+    return createSuccessResult();
+  }
+
+  // Map containing
+  if (original instanceof Map) {
+    if (!(actual instanceof Map)) {
+      return createFailureResult(context, {
+        kind: "type_mismatch",
+        message: `Expected Map for mapContaining(), got ${typeof actual}`,
+        actual,
+        expected: matcherInfo.payload,
+      });
+    }
+
+    for (const [key, expectedValue] of original.entries()) {
+      const keyContext = pushPath(context, { type: "mapKey", key });
+
+      if (!actual.has(key)) {
+        return createFailureResult(keyContext, {
+          kind: "map_key_missing",
+          message: `Map is missing key ${formatValue(key)}`,
+          actual: undefined,
+          expected: expectedValue,
+        });
+      }
+
+      const actualValue = actual.get(key);
+      const result = compareValuesDelegate(actualValue, expectedValue, keyContext);
+
+      if (!result.success) {
+        return result;
+      }
+    }
+
+    return createSuccessResult();
+  }
+
+  // Set containing
+  if (original instanceof Set) {
+    if (!(actual instanceof Set)) {
+      return createFailureResult(context, {
+        kind: "type_mismatch",
+        message: `Expected Set for setContaining(), got ${typeof actual}`,
+        actual,
+        expected: matcherInfo.payload,
+      });
+    }
+
+    const actualArray = Array.from(actual.values());
+
+    for (const expectedValue of original.values()) {
+      const found = actualArray.some((actualValue) => {
+        const result = compareValuesDelegate(actualValue, expectedValue, context);
+        return result.success;
+      });
+
+      if (!found) {
+        return createFailureResult(context, {
+          kind: "set_value_missing",
+          message: `Set does not contain expected value ${formatValue(expectedValue)}`,
+          actual,
+          expected: matcherInfo.payload,
+        });
+      }
+    }
+
+    return createSuccessResult();
+  }
+
+  // Object containing (partial match)
+  if (typeof original === "object" && original !== null) {
+    if (typeof actual !== "object" || actual === null) {
+      return createFailureResult(context, {
+        kind: "type_mismatch",
+        message: `Expected object for objectContaining(), got ${typeof actual}`,
+        actual,
+        expected: matcherInfo.payload,
+      });
+    }
+
+    const actualObj = actual as Record<string, unknown>;
+    const expectedObj = original as Record<string, unknown>;
+
+    for (const key of Object.keys(expectedObj)) {
+      const keyContext = pushPath(context, { type: "property", key });
+      const expectedValue = expectedObj[key];
+      const actualValue = actualObj[key];
+
+      const result = compareValuesDelegate(actualValue, expectedValue, keyContext);
+
+      if (!result.success) {
+        return result;
+      }
+    }
+
+    return createSuccessResult();
+  }
+
+  return createFailureResult(context, {
+    kind: "matcher_failed",
+    message: "Invalid containing matcher",
+    actual,
+    expected: matcherInfo.payload,
+  });
+}
+
+/**
+ * Format the containing matcher for display
+ */
+export function formatContainingMatcher(matcherInfo: MatcherInfo): string {
+  const original = matcherInfo.payload.original;
+  if (typeof original === "string") return `stringContaining("${original}")`;
+  if (Array.isArray(original)) return `arrayContaining([...])`;
+  if (original instanceof Map) return `mapContaining(Map)`;
+  if (original instanceof Set) return `setContaining(Set)`;
+  return `objectContaining({...})`;
+}

--- a/src/argsComparisons/compare-v2/matchers/index.ts
+++ b/src/argsComparisons/compare-v2/matchers/index.ts
@@ -1,0 +1,162 @@
+/**
+ * Matcher detection and dispatch
+ */
+
+import { CompareContext, CompareResult, MatcherInfo, MatcherType } from "../types";
+import { createFailureResult } from "../result";
+
+import { handleAnyMatcher } from "./any-matcher";
+import {
+  handleContainingMatcher,
+  setCompareValuesDelegate as setContainingDelegate,
+} from "./containing-matcher";
+import {
+  handleContainingDeepMatcher,
+  setCompareValuesDelegate as setContainingDeepDelegate,
+} from "./containing-deep-matcher";
+import { handleSchemaMatcher, handleValidateMatcher } from "./validate-matcher";
+import {
+  handleOrMatcher,
+  handleIsOneOfMatcher,
+  setCompareValuesDelegate as setOrDelegate,
+} from "./or-matcher";
+import {
+  handleStartsWithMatcher,
+  handleEndsWithMatcher,
+  handleMatchesRegexMatcher,
+} from "./string-matcher";
+import { handleInstanceOfMatcher } from "./instance-of-matcher";
+
+/**
+ * Initialize matcher delegates with the compareValues function
+ */
+export function initializeMatchers(
+  compareValues: (
+    actual: unknown,
+    expected: unknown,
+    context: CompareContext
+  ) => CompareResult
+): void {
+  setContainingDelegate(compareValues);
+  setContainingDeepDelegate(compareValues);
+  setOrDelegate(compareValues);
+}
+
+/**
+ * Detect if a value is a mockit matcher and extract its info
+ */
+export function detectMatcher(value: unknown): MatcherInfo | null {
+  if (typeof value !== "object" || value === null) {
+    return null;
+  }
+
+  const keys = Object.keys(value);
+  const matcherKey = keys.find((k) => k.startsWith("mockit__"));
+
+  if (!matcherKey) {
+    return null;
+  }
+
+  // Extract type from key: "mockit__any" -> "any"
+  const type = matcherKey.replace("mockit__", "") as MatcherType;
+
+  return {
+    type,
+    payload: value as Record<string, unknown>,
+  };
+}
+
+/**
+ * Check if an object contains any mockit matcher constructs (recursively)
+ */
+export function containsMockitConstruct(obj: unknown): boolean {
+  if (typeof obj !== "object" || obj === null) {
+    return false;
+  }
+
+  // Check if this object is a matcher
+  const keys = Object.keys(obj);
+  if (keys.some((key) => key.startsWith("mockit__"))) {
+    return true;
+  }
+
+  // Check arrays
+  if (Array.isArray(obj)) {
+    return obj.some((item) => containsMockitConstruct(item));
+  }
+
+  // Check Maps
+  if (obj instanceof Map) {
+    return Array.from(obj.values()).some((value) =>
+      containsMockitConstruct(value)
+    );
+  }
+
+  // Check Sets
+  if (obj instanceof Set) {
+    return Array.from(obj.values()).some((value) =>
+      containsMockitConstruct(value)
+    );
+  }
+
+  // Check object properties
+  return keys.some((key) => {
+    const value = (obj as Record<string, unknown>)[key];
+    if (typeof value === "object" && value !== null) {
+      return containsMockitConstruct(value);
+    }
+    return false;
+  });
+}
+
+/**
+ * Dispatch to the appropriate matcher handler
+ */
+export function dispatchToMatcherHandler(
+  actual: unknown,
+  matcherInfo: MatcherInfo,
+  context: CompareContext
+): CompareResult {
+  switch (matcherInfo.type) {
+    case "any":
+      return handleAnyMatcher(actual, matcherInfo, context);
+
+    case "isContaining":
+      return handleContainingMatcher(actual, matcherInfo, context);
+
+    case "isContainingDeep":
+      return handleContainingDeepMatcher(actual, matcherInfo, context);
+
+    case "isSchema":
+      return handleSchemaMatcher(actual, matcherInfo, context);
+
+    case "validate":
+      return handleValidateMatcher(actual, matcherInfo, context);
+
+    case "or_operator":
+      return handleOrMatcher(actual, matcherInfo, context);
+
+    case "isOneOf":
+      return handleIsOneOfMatcher(actual, matcherInfo, context);
+
+    case "instanceOf":
+      return handleInstanceOfMatcher(actual, matcherInfo, context);
+
+    case "startsWith":
+      return handleStartsWithMatcher(actual, matcherInfo, context);
+
+    case "endsWith":
+      return handleEndsWithMatcher(actual, matcherInfo, context);
+
+    case "matchesRegex":
+      return handleMatchesRegexMatcher(actual, matcherInfo, context);
+
+    default:
+      return createFailureResult(context, {
+        kind: "matcher_failed",
+        message: `Unknown matcher type: ${matcherInfo.type}`,
+        actual,
+        expected: matcherInfo.payload,
+      });
+  }
+}

--- a/src/argsComparisons/compare-v2/matchers/instance-of-matcher.ts
+++ b/src/argsComparisons/compare-v2/matchers/instance-of-matcher.ts
@@ -1,0 +1,58 @@
+/**
+ * Handler for instanceOf matcher
+ */
+
+import { CompareContext, CompareResult, MatcherInfo, formatValue } from "../types";
+import { createSuccessResult, createFailureResult } from "../result";
+
+/**
+ * Handle instanceOf matcher
+ */
+export function handleInstanceOfMatcher(
+  actual: unknown,
+  matcherInfo: MatcherInfo,
+  context: CompareContext
+): CompareResult {
+  const expectedClass = matcherInfo.payload.class as new (
+    ...args: unknown[]
+  ) => unknown;
+
+  if (actual instanceof expectedClass) {
+    return createSuccessResult();
+  }
+
+  const className = expectedClass.name || "Class";
+  const actualType = getActualTypeName(actual);
+
+  return createFailureResult(context, {
+    kind: "matcher_failed",
+    message: `Expected instance of ${className}, got ${actualType}`,
+    actual,
+    expected: matcherInfo.payload,
+  });
+}
+
+/**
+ * Get a descriptive type name for the actual value
+ */
+function getActualTypeName(actual: unknown): string {
+  if (actual === null) return "null";
+  if (actual === undefined) return "undefined";
+  if (typeof actual !== "object") return typeof actual;
+
+  // Try to get constructor name
+  const constructor = (actual as object).constructor;
+  if (constructor && constructor.name) {
+    return constructor.name;
+  }
+
+  return "object";
+}
+
+/**
+ * Format the instanceOf matcher for display
+ */
+export function formatInstanceOfMatcher(matcherInfo: MatcherInfo): string {
+  const expectedClass = matcherInfo.payload.class as { name?: string };
+  return `instanceOf(${expectedClass?.name || "Class"})`;
+}

--- a/src/argsComparisons/compare-v2/matchers/or-matcher.ts
+++ b/src/argsComparisons/compare-v2/matchers/or-matcher.ts
@@ -1,0 +1,84 @@
+/**
+ * Handler for or() and isOneOf() matchers
+ */
+
+import { CompareContext, CompareResult, MatcherInfo, formatValue } from "../types";
+import { createSuccessResult, createFailureResult } from "../result";
+
+// Forward declaration - will be set by index.ts to avoid circular imports
+let compareValuesDelegate: (
+  actual: unknown,
+  expected: unknown,
+  context: CompareContext
+) => CompareResult;
+
+export function setCompareValuesDelegate(
+  fn: (
+    actual: unknown,
+    expected: unknown,
+    context: CompareContext
+  ) => CompareResult
+): void {
+  compareValuesDelegate = fn;
+}
+
+/**
+ * Handle or() matcher - matches if ANY option matches
+ */
+export function handleOrMatcher(
+  actual: unknown,
+  matcherInfo: MatcherInfo,
+  context: CompareContext
+): CompareResult {
+  const options = matcherInfo.payload.options as unknown[];
+
+  for (const option of options) {
+    const result = compareValuesDelegate(actual, option, context);
+    if (result.success) {
+      return createSuccessResult();
+    }
+  }
+
+  return createFailureResult(context, {
+    kind: "matcher_failed",
+    message: `Value ${formatValue(actual)} did not match any of the ${options.length} options in or()`,
+    actual,
+    expected: matcherInfo.payload,
+  });
+}
+
+/**
+ * Handle isOneOf() matcher - matches if value is in the array of options
+ */
+export function handleIsOneOfMatcher(
+  actual: unknown,
+  matcherInfo: MatcherInfo,
+  context: CompareContext
+): CompareResult {
+  const options = matcherInfo.payload.options as unknown[];
+
+  for (const option of options) {
+    const result = compareValuesDelegate(actual, option, context);
+    if (result.success) {
+      return createSuccessResult();
+    }
+  }
+
+  return createFailureResult(context, {
+    kind: "matcher_failed",
+    message: `Value ${formatValue(actual)} is not one of the expected options: ${options.map(formatValue).join(", ")}`,
+    actual,
+    expected: matcherInfo.payload,
+  });
+}
+
+/**
+ * Format the or/isOneOf matcher for display
+ */
+export function formatOrMatcher(matcherInfo: MatcherInfo): string {
+  const options = matcherInfo.payload.options as unknown[];
+  if (matcherInfo.type === "isOneOf") {
+    return `isOneOf([${options.map(formatValue).join(", ")}])`;
+  }
+  return `or(${options.length} options)`;
+}

--- a/src/argsComparisons/compare-v2/matchers/string-matcher.ts
+++ b/src/argsComparisons/compare-v2/matchers/string-matcher.ts
@@ -1,0 +1,116 @@
+/**
+ * Handler for string pattern matchers
+ * stringStartingWith, stringEndingWith, stringMatching
+ */
+
+import { CompareContext, CompareResult, MatcherInfo, formatValue } from "../types";
+import { createSuccessResult, createFailureResult } from "../result";
+
+/**
+ * Handle stringStartingWith matcher
+ */
+export function handleStartsWithMatcher(
+  actual: unknown,
+  matcherInfo: MatcherInfo,
+  context: CompareContext
+): CompareResult {
+  const prefix = matcherInfo.payload.original as string;
+
+  if (typeof actual !== "string") {
+    return createFailureResult(context, {
+      kind: "type_mismatch",
+      message: `Expected string for stringStartingWith(), got ${typeof actual}`,
+      actual,
+      expected: matcherInfo.payload,
+    });
+  }
+
+  if (actual.startsWith(prefix)) {
+    return createSuccessResult();
+  }
+
+  return createFailureResult(context, {
+    kind: "matcher_failed",
+    message: `Expected string starting with "${prefix}", got "${actual}"`,
+    actual,
+    expected: matcherInfo.payload,
+  });
+}
+
+/**
+ * Handle stringEndingWith matcher
+ */
+export function handleEndsWithMatcher(
+  actual: unknown,
+  matcherInfo: MatcherInfo,
+  context: CompareContext
+): CompareResult {
+  const suffix = matcherInfo.payload.original as string;
+
+  if (typeof actual !== "string") {
+    return createFailureResult(context, {
+      kind: "type_mismatch",
+      message: `Expected string for stringEndingWith(), got ${typeof actual}`,
+      actual,
+      expected: matcherInfo.payload,
+    });
+  }
+
+  if (actual.endsWith(suffix)) {
+    return createSuccessResult();
+  }
+
+  return createFailureResult(context, {
+    kind: "matcher_failed",
+    message: `Expected string ending with "${suffix}", got "${actual}"`,
+    actual,
+    expected: matcherInfo.payload,
+  });
+}
+
+/**
+ * Handle stringMatching (regex) matcher
+ */
+export function handleMatchesRegexMatcher(
+  actual: unknown,
+  matcherInfo: MatcherInfo,
+  context: CompareContext
+): CompareResult {
+  const regexp = matcherInfo.payload.regexp as RegExp;
+
+  if (typeof actual !== "string") {
+    return createFailureResult(context, {
+      kind: "type_mismatch",
+      message: `Expected string for stringMatching(), got ${typeof actual}`,
+      actual,
+      expected: matcherInfo.payload,
+    });
+  }
+
+  if (regexp.test(actual)) {
+    return createSuccessResult();
+  }
+
+  return createFailureResult(context, {
+    kind: "matcher_failed",
+    message: `Expected string matching ${regexp}, got "${actual}"`,
+    actual,
+    expected: matcherInfo.payload,
+  });
+}
+
+/**
+ * Format the string matcher for display
+ */
+export function formatStringMatcher(matcherInfo: MatcherInfo): string {
+  switch (matcherInfo.type) {
+    case "startsWith":
+      return `stringStartingWith("${matcherInfo.payload.original}")`;
+    case "endsWith":
+      return `stringEndingWith("${matcherInfo.payload.original}")`;
+    case "matchesRegex":
+      return `stringMatching(${matcherInfo.payload.regexp})`;
+    default:
+      return "stringMatcher()";
+  }
+}

--- a/src/argsComparisons/compare-v2/matchers/validate-matcher.ts
+++ b/src/argsComparisons/compare-v2/matchers/validate-matcher.ts
@@ -1,0 +1,112 @@
+/**
+ * Handler for validation matchers
+ * validates() with custom function or Zod schema
+ */
+
+import { CompareContext, CompareResult, MatcherInfo, formatValue } from "../types";
+import { createSuccessResult, createFailureResult } from "../result";
+import { Schema } from "../../../behaviours/matchers";
+
+/**
+ * Handle isSchema matcher (Zod validation)
+ */
+export function handleSchemaMatcher(
+  actual: unknown,
+  matcherInfo: MatcherInfo,
+  context: CompareContext
+): CompareResult {
+  const schema = matcherInfo.payload.schema as Schema;
+
+  try {
+    const result = schema.safeParse(actual);
+
+    if (result.success) {
+      return createSuccessResult();
+    }
+
+    // Format Zod error - result.success is false here
+    const errorMessage = formatZodError(result as { success: false; error?: unknown });
+
+    return createFailureResult(context, {
+      kind: "matcher_failed",
+      message: `Zod validation failed: ${errorMessage}`,
+      actual,
+      expected: matcherInfo.payload,
+    });
+  } catch (error) {
+    return createFailureResult(context, {
+      kind: "matcher_failed",
+      message: `Zod validation threw: ${error}`,
+      actual,
+      expected: matcherInfo.payload,
+    });
+  }
+}
+
+/**
+ * Handle validate matcher (custom validation function)
+ */
+export function handleValidateMatcher(
+  actual: unknown,
+  matcherInfo: MatcherInfo,
+  context: CompareContext
+): CompareResult {
+  const validationFunction = matcherInfo.payload.validationFunction as (
+    value: unknown
+  ) => boolean;
+
+  try {
+    const result = validationFunction(actual);
+
+    if (result) {
+      return createSuccessResult();
+    }
+
+    return createFailureResult(context, {
+      kind: "matcher_failed",
+      message: `Custom validation function returned false for ${formatValue(actual)}`,
+      actual,
+      expected: matcherInfo.payload,
+    });
+  } catch (error) {
+    return createFailureResult(context, {
+      kind: "matcher_failed",
+      message: `Custom validation function threw: ${error}`,
+      actual,
+      expected: matcherInfo.payload,
+    });
+  }
+}
+
+/**
+ * Format Zod error for display
+ */
+function formatZodError(result: { success: false; error?: unknown }): string {
+  const error = result.error as {
+    issues?: Array<{ path?: unknown[]; message?: string }>;
+  };
+
+  if (!error || !error.issues || error.issues.length === 0) {
+    return "validation failed";
+  }
+
+  const firstIssue = error.issues[0];
+  const path = firstIssue.path?.join(".") || "";
+  const message = firstIssue.message || "invalid";
+
+  if (path) {
+    return `at "${path}": ${message}`;
+  }
+
+  return message;
+}
+
+/**
+ * Format the validation matcher for display
+ */
+export function formatValidateMatcher(matcherInfo: MatcherInfo): string {
+  if (matcherInfo.type === "isSchema") {
+    return "validates(ZodSchema)";
+  }
+  return "validates(fn)";
+}

--- a/src/argsComparisons/compare-v2/result.ts
+++ b/src/argsComparisons/compare-v2/result.ts
@@ -1,0 +1,180 @@
+/**
+ * Result builders for compare-v2
+ */
+
+import { getCurrentPathString } from "./context";
+import {
+  CompareContext,
+  CompareResult,
+  MismatchInfo,
+  MismatchKind,
+  formatPath,
+  formatValue,
+} from "./types";
+
+/**
+ * Create a successful comparison result
+ */
+export function createSuccessResult(): CompareResult {
+  return {
+    success: true,
+    mismatches: [],
+  };
+}
+
+/**
+ * Create a failure result with a single mismatch
+ */
+export function createFailureResult(
+  context: CompareContext,
+  info: {
+    kind: MismatchKind;
+    message: string;
+    actual: unknown;
+    expected: unknown;
+  }
+): CompareResult {
+  const mismatch: MismatchInfo = {
+    path: [...context.path],
+    pathString: formatPath(context.path),
+    actual: info.actual,
+    expected: info.expected,
+    kind: info.kind,
+    message: info.message,
+  };
+
+  return {
+    success: false,
+    mismatches: [mismatch],
+  };
+}
+
+/**
+ * Merge multiple comparison results into one
+ * If any result is a failure, the merged result is a failure
+ */
+export function mergeResults(results: CompareResult[]): CompareResult {
+  const allMismatches: MismatchInfo[] = [];
+  let allSuccess = true;
+
+  for (const result of results) {
+    if (!result.success) {
+      allSuccess = false;
+      allMismatches.push(...result.mismatches);
+    }
+  }
+
+  return {
+    success: allSuccess,
+    mismatches: allMismatches,
+  };
+}
+
+/**
+ * Add a mismatch to an existing result
+ */
+export function addMismatch(
+  result: CompareResult,
+  mismatch: MismatchInfo
+): CompareResult {
+  return {
+    success: false,
+    mismatches: [...result.mismatches, mismatch],
+  };
+}
+
+/**
+ * Create a mismatch info object
+ */
+export function createMismatch(
+  context: CompareContext,
+  kind: MismatchKind,
+  actual: unknown,
+  expected: unknown,
+  message: string
+): MismatchInfo {
+  return {
+    path: [...context.path],
+    pathString: formatPath(context.path),
+    actual,
+    expected,
+    kind,
+    message,
+  };
+}
+
+/**
+ * Helper to create common mismatch types
+ */
+export const Mismatches = {
+  typeMismatch(
+    context: CompareContext,
+    actual: unknown,
+    expected: unknown
+  ): CompareResult {
+    return createFailureResult(context, {
+      kind: "type_mismatch",
+      message: `Expected type ${typeof expected}, got ${typeof actual}`,
+      actual,
+      expected,
+    });
+  },
+
+  valueMismatch(
+    context: CompareContext,
+    actual: unknown,
+    expected: unknown
+  ): CompareResult {
+    return createFailureResult(context, {
+      kind: "value_mismatch",
+      message: `Expected ${formatValue(expected)}, got ${formatValue(actual)}`,
+      actual,
+      expected,
+    });
+  },
+
+  missingProperty(
+    context: CompareContext,
+    key: string,
+    expected: unknown
+  ): CompareResult {
+    return createFailureResult(context, {
+      kind: "missing_property",
+      message: `Missing property "${key}"`,
+      actual: undefined,
+      expected,
+    });
+  },
+
+  matcherFailed(
+    context: CompareContext,
+    actual: unknown,
+    expected: unknown,
+    matcherDescription: string
+  ): CompareResult {
+    return createFailureResult(context, {
+      kind: "matcher_failed",
+      message: `Expected ${matcherDescription}, got ${formatValue(actual)}`,
+      actual,
+      expected,
+    });
+  },
+
+  circularReference(context: CompareContext): CompareResult {
+    return createFailureResult(context, {
+      kind: "circular_reference",
+      message: "Circular reference detected",
+      actual: "[Circular]",
+      expected: "[Circular]",
+    });
+  },
+
+  maxDepthExceeded(context: CompareContext): CompareResult {
+    return createFailureResult(context, {
+      kind: "max_depth_exceeded",
+      message: `Maximum comparison depth (${context.options.maxDepth}) exceeded`,
+      actual: "[Too Deep]",
+      expected: "[Too Deep]",
+    });
+  },
+};

--- a/src/argsComparisons/compare-v2/types.ts
+++ b/src/argsComparisons/compare-v2/types.ts
@@ -1,0 +1,263 @@
+/**
+ * Types for the compare-v2 implementation
+ */
+
+// =============================================================================
+// Path Types
+// =============================================================================
+
+/**
+ * Represents a single segment in the path to a value
+ */
+export type PathSegment =
+  | { type: "property"; key: string }
+  | { type: "index"; index: number }
+  | { type: "mapKey"; key: unknown }
+  | { type: "setValue"; value: unknown };
+
+/**
+ * A full path from root to current position
+ */
+export type Path = PathSegment[];
+
+/**
+ * Formats a path for human-readable output
+ * e.g., [{ type: "property", key: "user" }, { type: "index", index: 0 }] -> "user[0]"
+ */
+export function formatPath(path: Path): string {
+  if (path.length === 0) return "<root>";
+
+  return path.reduce((acc, segment) => {
+    switch (segment.type) {
+      case "property":
+        return acc ? `${acc}.${segment.key}` : segment.key;
+      case "index":
+        return `${acc}[${segment.index}]`;
+      case "mapKey":
+        return `${acc}.get(${formatValue(segment.key)})`;
+      case "setValue":
+        return `${acc}.has(${formatValue(segment.value)})`;
+    }
+  }, "");
+}
+
+// =============================================================================
+// Mismatch Types
+// =============================================================================
+
+/**
+ * Types of mismatches that can occur during comparison
+ */
+export type MismatchKind =
+  | "type_mismatch"
+  | "value_mismatch"
+  | "missing_property"
+  | "extra_property"
+  | "array_length"
+  | "matcher_failed"
+  | "circular_reference"
+  | "max_depth_exceeded"
+  | "map_key_missing"
+  | "set_value_missing";
+
+/**
+ * Describes a single mismatch between expected and actual values
+ */
+export interface MismatchInfo {
+  /** Path where the mismatch occurred */
+  path: Path;
+  /** Human-readable formatted path */
+  pathString: string;
+  /** The actual value found */
+  actual: unknown;
+  /** The expected value/matcher */
+  expected: unknown;
+  /** Type of mismatch */
+  kind: MismatchKind;
+  /** Human-readable message */
+  message: string;
+}
+
+// =============================================================================
+// Compare Result
+// =============================================================================
+
+/**
+ * The result of a comparison
+ */
+export interface CompareResult {
+  /** Whether the comparison succeeded */
+  success: boolean;
+  /** List of all mismatches found (empty if success) */
+  mismatches: MismatchInfo[];
+}
+
+// =============================================================================
+// Compare Options
+// =============================================================================
+
+/**
+ * Options for the comparison
+ */
+export interface CompareOptions {
+  /**
+   * When true, treat { a: 1 } and { a: 1, b: undefined } as equal
+   * Default: true (new behavior)
+   */
+  treatUndefinedAsAbsent: boolean;
+
+  /**
+   * Maximum recursion depth (prevents stack overflow)
+   * Default: 100
+   */
+  maxDepth: number;
+
+  /**
+   * Collect all mismatches (true) or stop at first (false)
+   * Default: true for better error messages
+   */
+  collectAllMismatches: boolean;
+}
+
+/**
+ * Default options for comparison
+ */
+export const DEFAULT_OPTIONS: CompareOptions = {
+  treatUndefinedAsAbsent: true,
+  maxDepth: 100,
+  collectAllMismatches: true,
+};
+
+// =============================================================================
+// Compare Context
+// =============================================================================
+
+/**
+ * Internal context passed through the comparison
+ */
+export interface CompareContext {
+  /** Current options */
+  options: CompareOptions;
+  /** Current path in the object tree */
+  path: Path;
+  /** Visited objects from actual (for circular ref detection) */
+  visitedActual: WeakSet<object>;
+  /** Visited objects from expected (for circular ref detection) */
+  visitedExpected: WeakSet<object>;
+  /** Current depth */
+  depth: number;
+}
+
+// =============================================================================
+// Matcher Types
+// =============================================================================
+
+/**
+ * All supported matcher types
+ */
+export type MatcherType =
+  | "any"
+  | "isContaining"
+  | "isContainingDeep"
+  | "isSchema"
+  | "validate"
+  | "or_operator"
+  | "isOneOf"
+  | "instanceOf"
+  | "startsWith"
+  | "endsWith"
+  | "matchesRegex";
+
+/**
+ * Detection result for a matcher
+ */
+export interface MatcherInfo {
+  type: MatcherType;
+  payload: Record<string, unknown>;
+}
+
+// =============================================================================
+// Utility Functions
+// =============================================================================
+
+/**
+ * Format a value for display in error messages
+ */
+export function formatValue(value: unknown): string {
+  if (value === undefined) return "undefined";
+  if (value === null) return "null";
+  if (typeof value === "string") return `"${value}"`;
+  if (typeof value === "function") return "[Function]";
+  if (typeof value === "symbol") return value.toString();
+  if (value instanceof Map) return `Map(${value.size})`;
+  if (value instanceof Set) return `Set(${value.size})`;
+  if (Array.isArray(value)) {
+    if (value.length <= 3) {
+      return `[${value.map(formatValue).join(", ")}]`;
+    }
+    return `[${value.slice(0, 3).map(formatValue).join(", ")}, ... (${value.length} items)]`;
+  }
+  if (typeof value === "object") {
+    // Check if it's a matcher
+    const keys = Object.keys(value);
+    const matcherKey = keys.find((k) => k.startsWith("mockit__"));
+    if (matcherKey) {
+      return formatMatcherValue(value as Record<string, unknown>, matcherKey);
+    }
+    const keyCount = keys.length;
+    if (keyCount <= 2) {
+      return `{ ${keys.map((k) => `${k}: ${formatValue((value as Record<string, unknown>)[k])}`).join(", ")} }`;
+    }
+    return `{ ${keys.slice(0, 2).map((k) => `${k}: ${formatValue((value as Record<string, unknown>)[k])}`).join(", ")}, ... (${keyCount} keys) }`;
+  }
+  return String(value);
+}
+
+/**
+ * Format a matcher for display
+ */
+function formatMatcherValue(
+  matcher: Record<string, unknown>,
+  matcherKey: string
+): string {
+  const type = matcherKey.replace("mockit__", "");
+
+  switch (type) {
+    case "any":
+      return `any${capitalize(matcher.what as string)}()`;
+    case "isContaining":
+      if (typeof matcher.original === "string")
+        return `stringContaining("${matcher.original}")`;
+      if (Array.isArray(matcher.original)) return `arrayContaining([...])`;
+      if (matcher.original instanceof Map) return `mapContaining(Map)`;
+      if (matcher.original instanceof Set) return `setContaining(Set)`;
+      return `objectContaining({...})`;
+    case "isContainingDeep":
+      if (Array.isArray(matcher.original)) return `arrayContainingDeep([...])`;
+      if (matcher.original instanceof Map) return `mapContainingDeep(Map)`;
+      if (matcher.original instanceof Set) return `setContainingDeep(Set)`;
+      return `objectContainingDeep({...})`;
+    case "isSchema":
+      return `validates(ZodSchema)`;
+    case "validate":
+      return `validates(fn)`;
+    case "or_operator":
+      return `or(...)`;
+    case "isOneOf":
+      return `isOneOf([...])`;
+    case "instanceOf":
+      return `instanceOf(${(matcher.class as { name: string })?.name || "Class"})`;
+    case "startsWith":
+      return `stringStartingWith("${matcher.original}")`;
+    case "endsWith":
+      return `stringEndingWith("${matcher.original}")`;
+    case "matchesRegex":
+      return `stringMatching(${matcher.regexp})`;
+    default:
+      return `matcher(${type})`;
+  }
+}
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}

--- a/src/argsComparisons/compare.ts
+++ b/src/argsComparisons/compare.ts
@@ -1,308 +1,46 @@
-import { hasher } from "../hasher";
-import { Schema } from "../behaviours/matchers";
-import { containingDeep } from "../behaviours/containing.deep";
+/**
+ * Compare function - Entry point for argument comparison
+ *
+ * This module wraps the new compare-v2 implementation while maintaining
+ * backward compatibility with the existing boolean-returning API.
+ */
 
-// TODO: schemas in maps & sets & arrays
+import {
+  compare as compareV2,
+  CompareResult,
+  CompareOptions,
+} from "./compare-v2";
+
+/**
+ * Compare two values for equality.
+ * Supports matchers like anyString(), objectContaining(), etc.
+ *
+ * @param actual The actual value received
+ * @param expected The expected value or matcher
+ * @returns true if values match, false otherwise
+ */
 export function compare(actual: any, expected: any): boolean {
-  if (typeof expected === "object" && expected !== null) {
-    // fyi, (typeof null) equals "object". I know. #javascript
-
-    const isOROperator = Object.keys(expected).some((key) =>
-      key.endsWith("mockit__or_operator")
-    );
-    if (isOROperator) {
-      return expected.options.some((option: any) => compare(actual, option));
-    }
-
-    const isInstanceOf = Object.keys(expected).some((key) =>
-      key.endsWith("mockit__instanceOf")
-    );
-
-    if (isInstanceOf) {
-      return actual instanceof expected.class;
-    }
-
-    const isSchema = Object.keys(expected).some((key) =>
-      key.endsWith("mockit__isSchema")
-    );
-    if (isSchema) {
-      return (expected.schema as Schema).safeParse(actual).success;
-    }
-
-    const isValidate = Object.keys(expected).some((key) =>
-      key.endsWith("mockit__validate")
-    );
-    if (isValidate) {
-      return expected.validationFunction(actual);
-    }
-
-    const isOneOf = Object.keys(expected).some((key) =>
-      key.endsWith("mockit__isOneOf")
-    );
-    if (isOneOf) {
-      return expected.options.some((option: unknown) => compare(actual, option));
-    }
-
-    const isStartsWith = Object.keys(expected).some((key) =>
-      key.endsWith("mockit__startsWith")
-    );
-    if (isStartsWith) {
-      return actual?.startsWith?.(expected.original);
-    }
-
-    const isEndsWith = Object.keys(expected).some((key) =>
-      key.endsWith("mockit__endsWith")
-    );
-    if (isEndsWith) {
-      return actual?.endsWith?.(expected.original);
-    }
-
-    const isRegexp = Object.keys(expected).some((key) =>
-      key.endsWith("mockit__matchesRegex")
-    );
-    if (isRegexp) {
-      return expected.regexp?.test?.(actual);
-    }
-
-    const isAnyOf = Object.keys(expected).some((key) =>
-      key.endsWith("mockit__any")
-    );
-
-    if (isAnyOf) {
-      switch (expected.what) {
-        case "object":
-          if (Array.isArray(actual)) {
-            return false;
-          }
-
-          if (actual == null) {
-            return false;
-          }
-
-          if (actual instanceof Map) {
-            return false;
-          }
-
-          if (actual instanceof Set) {
-            return false;
-          }
-
-          return typeof actual === "object";
-
-        case "function":
-        case "undefined":
-        case "string":
-        case "boolean":
-          return typeof actual === expected.what;
-        case "number":
-          return typeof actual === "number" && !isNaN(actual);
-        case "nullish":
-          return actual == null;
-        case "array":
-          return Array.isArray(actual);
-        case "map":
-          return actual instanceof Map;
-        case "set":
-          return actual instanceof Set;
-        case "falsy":
-          return !actual;
-        case "truthy":
-          return !!actual;
-        default:
-          return false;
-      }
-    }
-
-    const isContaining = Object.keys(expected).some((key) =>
-      key.endsWith("mockit__isContaining")
-    );
-    if (isContaining) {
-      // arrayContaining
-      if (Array.isArray(expected.original)) {
-        return expected.original.every((item: unknown, index: number) => {
-          return actual?.some((actualItem: unknown) => compare(actualItem, item));
-        });
-      }
-
-      // mapContaining
-      if (expected.original instanceof Map) {
-        return Array.from(
-          ((expected?.original as Map<unknown, unknown>) ?? []).entries()
-        ).every(([key, value]) => {
-          return compare(actual.get(key), value);
-        });
-      }
-
-      // setContaining
-      if (expected.original instanceof Set) {
-        return Array.from(
-          ((expected?.original as Set<unknown>) ?? []).values()
-        ).every((value) => {
-          return Array.from(actual?.values?.() ?? []).some((actualValue) =>
-            compare(actualValue, value)
-          );
-        });
-      }
-
-      // stringContaining
-      if (typeof expected?.original === "string") {
-        const isContaining = Object.keys(expected).some((key) =>
-          key.endsWith("mockit__isContaining")
-        );
-        if (isContaining) {
-          return actual.includes(expected?.original);
-        }
-      }
-
-      // objectContaining
-      return Object.keys(expected.original).every((key) => {
-        return compare(actual[key], expected.original[key]);
-      });
-    }
-
-    const isContainingDeep = Object.keys(expected).some((key) =>
-      key.endsWith("mockit__isContainingDeep")
-    );
-    if (isContainingDeep) {
-      if (typeof actual !== "object") {
-        return hasher.hash(actual) === hasher.hash(expected.original);
-      }
-
-      if (Array.isArray(expected.original)) {
-        return expected.original.every((expectedValue: unknown) => {
-          return actual?.some((actualValue: unknown) =>
-            compare(actualValue, containingDeep(expectedValue))
-          );
-        });
-      }
-
-      if (expected.original instanceof Map) {
-        return Array.from(
-          ((expected?.original as Map<any, any>) ?? []).entries()
-        ).every(([key, expectedVAlue]) => {
-          return compare(actual.get(key), containingDeep(expectedVAlue));
-        });
-      }
-
-      if (expected.original instanceof Set) {
-        return Array.from(
-          ((expected?.original as Set<any>) ?? []).values()
-        ).every((expectedValue) => {
-          return Array.from(actual.values()).some((actualValue) =>
-            compare(actualValue, containingDeep(expectedValue))
-          );
-        });
-      }
-
-      if (typeof expected.original !== "object") {
-        // For simple values that were stuck in the containingDeep regression
-        return compare(actual, expected.original);
-      }
-
-      return Object.keys(expected.original).every((key) => {
-        return compare(actual[key], containingDeep(expected.original[key]));
-      });
-    }
-
-    /**
-     *
-     * From this point onwards, we're dealing with expected objects that are not first-class constructs
-     * (meaning they are not partials, containings, partialDeeps, etc, but they could contain some of those)
-     *  ==> we will check if the object contains a construct, we recursively call compare on the object properties
-     * depending on its structure:
-     * - if it's an array, we call compare on each item
-     * - if it's a map, we call compare on each value
-     * - if it's a set, we call compare on each value
-     * - if it's an object, we call compare on each property
-     **/
-
-    // Not sure the containsSchema check is necessary anymore. Should try removing it
-    const dataContainsMockitConstruct = containsMockitConstruct(
-      expected,
-      "mockit__"
-    );
-
-    if (dataContainsMockitConstruct) {
-      if (Array.isArray(expected)) {
-        return expected.every((item, index) => {
-          return compare(actual[index], item);
-        });
-      }
-
-      if (expected instanceof Map) {
-        return Array.from(expected.entries()).every(([key, value]) => {
-          return compare(actual.get(key), value);
-        });
-      }
-
-      if (expected instanceof Set) {
-        return Array.from(expected.values()).every((expectedValue) => {
-          return Array.from(actual?.values?.() ?? []).some((actualValue) =>
-            compare(actualValue, expectedValue)
-          );
-        });
-      }
-
-      return Object.keys(expected).every((key) => {
-        return compare(actual?.[key], expected?.[key]);
-      });
-    }
-  }
-
-  /**
-   * Now we're pretty much left with normal values in a normal context (no constructs).
-   * We can compare them directly:
-   * - if the typeof is different, we return false
-   * - then, we compare the hashes of the actual and expected values (a bit more expensive that a typeof comparison)
-   */
-
-  if (typeof actual !== typeof expected) {
-    return false;
-  }
-
-  return hasher.hash(actual) === hasher.hash(expected);
+  return compareV2(actual, expected).success;
 }
 
-function containsMockitConstruct(
-  obj: any,
-  construct:
-    | "mockit__"
-    | "mockit__isSchema"
-    | "mockit__isPartial"
-    | "mockit__isContaining"
-    | "mockit__isPartialDeep"
-    | "mockit__isContainingDeep"
-): boolean {
-  if (typeof obj !== "object") {
-    return false;
-  }
-
-  if (Array.isArray(obj)) {
-    return obj.some((item) => containsMockitConstruct(item, construct));
-  }
-
-  if (obj instanceof Map) {
-    return Array.from(obj.values()).some((value) =>
-      containsMockitConstruct(value, construct)
-    );
-  }
-
-  if (obj instanceof Set) {
-    return Array.from(obj.values()).some((value) =>
-      containsMockitConstruct(value, construct)
-    );
-  }
-
-  const keys = Object.keys(obj ?? {});
-  if (keys.some((key) => key.startsWith(construct))) {
-    return true;
-  }
-
-  return keys.some((key) => {
-    if (typeof obj[key] === "object") {
-      return containsMockitConstruct(obj[key], construct);
-    }
-
-    return false;
-  });
+/**
+ * Compare two values and get detailed results.
+ * Use this when you need information about what didn't match.
+ *
+ * @param actual The actual value received
+ * @param expected The expected value or matcher
+ * @param options Optional comparison options
+ * @returns CompareResult with success status and mismatch details
+ */
+export function compareDetailed(
+  actual: any,
+  expected: any,
+  options?: Partial<CompareOptions>
+): CompareResult {
+  return compareV2(actual, expected, options);
 }
+
+// Re-export types for advanced usage
+export type { CompareResult, CompareOptions } from "./compare-v2";
+export type { MismatchInfo, MismatchKind, Path, PathSegment } from "./compare-v2";
+export { formatPath, formatValue, DEFAULT_OPTIONS } from "./compare-v2";

--- a/src/assertions/verifyThat.ts
+++ b/src/assertions/verifyThat.ts
@@ -1,165 +1,94 @@
 import { getMockHistory } from "./getMockHistory";
+import { compareDetailed, CompareResult, formatValue } from "../argsComparisons/compare";
+import { formatResult, formatVisualDiff } from "../argsComparisons/compare-v2/formatters";
+
+/**
+ * Options for verify assertions
+ */
+export interface VerifyOptions {
+  /** Show everything without truncation */
+  verbose?: boolean;
+}
 
 /**
  * Returns a list of assertion methods on the behaviour of a mocked function.
- * @param mockedFunction the mocked function whose behaviour you want to assert on
- * @returns nothing: this function will throw an error if the assertion fails
- *
- * @example
- * ```ts
- * function myFunction(...args: any[]) { return; }
- *
- * const mock = Mock(myFunction);
- *
- * verifyThat(mock).wasNeverCalled();
-
- * mock("hello", "world");
- * mock(1, 22, 333, 4444);
- *
- * verifyThat(mock).wasCalled();
- * verifyThat(mock).wasCalledWith("hello", "world");
- * verifyThat(mock).wasCalledWith(1, 22, 333, 4444);
- * verifyThat(mock).wasNeverCalledWith(777);
- * ```
  */
 export function verifyThat<TFunc extends (...args: any[]) => any>(
-  mockedFunction: TFunc
+  mockedFunction: TFunc,
+  options: VerifyOptions = {}
 ) {
   if (!Reflect.get(mockedFunction, "isMockitMock")) {
     throw new Error("This is not a mockit mock");
   }
 
   const mockHistory = getMockHistory(mockedFunction);
+  const { verbose = false } = options;
+
   return {
-    /**
-     * Asserts that the mocked function was called at least once.
-     * @returns nothing: this function will throw an error if the assertion fails
-     * @example
-     * ```ts
-     * function myFunction(...args: any[]) { return; }
-     *
-     * const mock = Mock(myFunction);
-     * mock();
-     * verifyThat(mock).wasCalled();
-     * ```
-     */
     wasCalled() {
       if (!mockHistory.wasCalled()) {
         throw new Error(`Function was never called.`);
       }
     },
-    /**
-     * Asserts that the mocked function was called with the specified arguments.
-     * @param args the arguments that the mocked function should have been called with
-     * @returns nothing: this function will throw an error if the assertion fails
-     * @example
-     * ```ts
-     * function myFunction(...args: any[]) { return; }
-     *
-     * const mock = Mock(myFunction);
-     *
-     * mock("hello", "world");
-     *
-     * verifyThat(mock).wasCalledWith("hello", "world");
-     * ```
-     */
+
     wasCalledWith(...args: Parameters<TFunc>) {
-      if (!mockHistory.wasCalledWith(...args)) {
-        throw new Error(`Function was not called with parameters ${args}`);
+      const calls = mockHistory.getCalls();
+
+      // Compare each call and collect results with mismatch count
+      const callResults: Array<{
+        args: unknown[];
+        result: CompareResult;
+        mismatchCount: number;
+      }> = [];
+
+      for (const call of calls) {
+        const result = compareDetailed(call.args, args);
+        if (result.success) {
+          return; // Found a match!
+        }
+        callResults.push({
+          args: call.args as unknown[],
+          result,
+          mismatchCount: result.mismatches.length,
+        });
       }
+
+      // No match found - build error message
+      throw new Error(buildError(args, callResults, verbose));
     },
-    /**
-     * Asserts that the mocked function was called exactly once.
-     * @returns nothing: this function will throw an error if the assertion fails
-     * @example
-     * ```ts
-     * function myFunction(...args: any[]) { return; }
-     *
-     * const mock = Mock(myFunction);
-     *
-     * mock();
-     *
-     * verifyThat(mock).wasCalledOnce();
-     *
-     * mock();
-     *
-     * // this will throw an error
-     * verifyThat(mock).wasCalledOnce();
-     * ```
-     */
+
     wasCalledOnce() {
       if (!mockHistory.wasCalledOnce()) {
-        throw new Error(`Function was not called exactly once.`);
-      }
-    },
-    /**
-     * Asserts that the mocked function was called exactly once with the specified arguments.
-     * @param args the arguments that the mocked function should have been called with
-     * @returns nothing: this function will throw an error if the assertion fails
-     * @example
-     * ```ts
-     * function myFunction(...args: any[]) { return; }
-     *
-     * const mock = Mock(myFunction);
-     *
-     * mock("hello", "world");
-     *
-     * verifyThat(mock).wasCalledOnceWith("hello", "world");
-     * ```
-     */
-    wasCalledOnceWith(...args: Parameters<TFunc>) {
-      if (!mockHistory.wasCalledOnceWith(...args)) {
+        const calls = mockHistory.getCalls();
         throw new Error(
-          `Function was not called exactly once with parameters ${args}`
+          `Function was not called exactly once. Called ${calls.length} time(s).`
         );
       }
     },
-    /**
-     * Asserts that the mocked function was called exactly n times.
-     * @param howMuch the number of times the mocked function should have been called
-     * @returns nothing: this function will throw an error if the assertion fails
-     * @example
-     * ```ts
-     * function myFunction(...args: any[]) { return; }
-     *
-     * const mock = Mock(myFunction);
-     *
-     * mock();
-     * mock();
-     *
-     * verifyThat(mock).wasCalledNTimes(2);
-     *
-     * mock();
-     *
-     * // this will throw an error
-     * verifyThat(mock).wasCalledNTimes(2);
-     * ```
-     */
-    wasCalledNTimes(howMuch: number) {
-      if (!mockHistory.wasCalledNTimes(howMuch)) {
-        throw new Error(`Function was not called exactly ${howMuch} times.`);
+
+    wasCalledOnceWith(...args: Parameters<TFunc>) {
+      const calls = mockHistory.getCalls();
+      const matchingCalls = calls.filter(
+        (call) => compareDetailed(call.args, args).success
+      );
+
+      if (matchingCalls.length !== 1) {
+        throw new Error(
+          `Function was not called exactly once with expected parameters. ` +
+            `Found ${matchingCalls.length} matching call(s) out of ${calls.length} total call(s).`
+        );
       }
     },
-    /**
-     * Asserts that the mocked function was called exactly n times with the specified arguments.
-     * @param howMuch the number of times the mocked function should have been called
-     * @param args the arguments that the mocked function should have been called with
-     * @returns nothing: this function will throw an error if the assertion fails
-     * @example
-     * ```ts
-     * function myFunction(...args: any[]) { return; }
-     *
-     * const mock = Mock(myFunction);
-     *
-     * mock("hello", "world");
-     *
-     * verifyThat(mock).wasCalledNTimesWith({ args: ["hello", "world"], howMuch: 1 });
-     *
-     * mock("hello", "world");
-     * mock("hello", "world");
-     *
-     * verifyThat(mock).wasCalledNTimesWith({ args: ["hello", "world"], howMuch: 3 });
-     */
+
+    wasCalledNTimes(howMuch: number) {
+      if (!mockHistory.wasCalledNTimes(howMuch)) {
+        const calls = mockHistory.getCalls();
+        throw new Error(
+          `Function was not called exactly ${howMuch} times. Called ${calls.length} time(s).`
+        );
+      }
+    },
+
     wasCalledNTimesWith({
       args,
       howMuch,
@@ -167,57 +96,83 @@ export function verifyThat<TFunc extends (...args: any[]) => any>(
       howMuch: number;
       args: Parameters<TFunc>;
     }) {
-      if (!mockHistory.wasCalledNTimesWith({ args, howMuch })) {
+      const calls = mockHistory.getCalls();
+      const matchingCalls = calls.filter(
+        (call) => compareDetailed(call.args, args).success
+      );
+
+      if (matchingCalls.length !== howMuch) {
         throw new Error(
-          `Function was not called exactly ${howMuch} times with parameters ${args}`
+          `Function was not called exactly ${howMuch} times with expected parameters. ` +
+            `Found ${matchingCalls.length} matching call(s) out of ${calls.length} total call(s).`
         );
       }
     },
-    /**
-     * Asserts that the mocked function was never called.
-     * @returns nothing: this function will throw an error if the assertion fails
-     * @example
-     * ```ts
-     * function myFunction(...args: any[]) { return; }
-     *
-     * const mock = Mock(myFunction);
-     *
-     * verifyThat(mock).wasNeverCalled();
-     *
-     * mock();
-     *
-     * // this will throw an error
-     * verifyThat(mock).wasNeverCalled();
-     * ```
-     */
+
     wasNeverCalled() {
       if (!mockHistory.wasNeverCalled()) {
-        throw new Error(`Function was called.`);
+        const calls = mockHistory.getCalls();
+        throw new Error(`Function was called ${calls.length} time(s).`);
       }
     },
 
-    /**
-     * Asserts that the mocked function was never called with the specified arguments.
-     * @param args the arguments that the mocked function should not have been called with
-     * @returns nothing: this function will throw an error if the assertion fails
-     * @example
-     * ```ts
-     * function myFunction(...args: any[]) { return; }
-     *
-     * const mock = Mock(myFunction);
-     *
-     * verifyThat(mock).wasNeverCalledWith("hello", "world");
-     *
-     * mock("hello", "world");
-     *
-     * // this will throw an error
-     * verifyThat(mock).wasNeverCalledWith("hello", "world");
-     * ```
-     */
     wasNeverCalledWith(...args: Parameters<TFunc>) {
       if (!mockHistory.wasNeverCalledWith(...args)) {
-        throw new Error(`Function was called with parameters ${args}`);
+        throw new Error(
+          `Function was called with parameters ${formatArgs(args)}`
+        );
       }
     },
   };
+}
+
+/**
+ * Build error message showing closest calls with diffs
+ */
+function buildError(
+  expectedArgs: unknown[],
+  callResults: Array<{ args: unknown[]; result: CompareResult; mismatchCount: number }>,
+  verbose: boolean
+): string {
+  const parts: string[] = [];
+
+  if (callResults.length === 0) {
+    parts.push("Function was never called.");
+    parts.push("");
+    parts.push(`Expected: ${formatArgs(expectedArgs)}`);
+    return parts.join("\n");
+  }
+
+  parts.push("Function was not called with expected parameters.");
+  parts.push("");
+  parts.push(`Expected: ${formatArgs(expectedArgs)}`);
+  parts.push("");
+
+  // Sort by mismatch count (closest first)
+  const sorted = [...callResults].sort((a, b) => a.mismatchCount - b.mismatchCount);
+
+  // Show top 3 closest calls with their diffs
+  const closestCalls = verbose ? sorted : sorted.slice(0, 3);
+
+  parts.push(`Closest call(s):`);
+  parts.push("");
+
+  closestCalls.forEach((call, i) => {
+    parts.push(`--- Call ${i + 1} (${call.mismatchCount} difference(s)) ---`);
+    parts.push(`Arguments: ${formatArgs(call.args)}`);
+    parts.push("");
+    parts.push(formatResult(call.result, expectedArgs, call.args, { verbose }));
+    parts.push("");
+  });
+
+  if (!verbose && sorted.length > 3) {
+    parts.push(`... and ${sorted.length - 3} other call(s)`);
+  }
+
+  return parts.join("\n");
+}
+
+function formatArgs(args: unknown[]): string {
+  if (args.length === 0) return "()";
+  return `(${args.map((a) => formatValue(a)).join(", ")})`;
 }


### PR DESCRIPTION
## Summary

Complete rewrite of the `compare` function with a modular architecture. This improves error messages in `verifyThat()` with visual diffs.

## Motivation

The previous `compare` function had issues:
- Stack overflow on circular references
- No diff when assertions failed (just "not called with expected parameters")
- `{ a: 1 }` didn't match `{ a: 1, b: undefined }`

## What's new

### 1. Visual diff on assertion failures

When `wasCalledWith()` fails, you now get a clear diff:

```
Function was not called with expected parameters.

Expected: ("John", 25)

Closest call(s):

--- Call 1 (1 difference(s)) ---
Arguments: ("John", 99)

Visual diff:
- Expected  - 1
+ Received  + 1

  [
    "John",
-   25,
+   99,
  ]
```

### 2. Matchers display properly in diffs

```
Visual diff:
- Expected  - 1
+ Received  + 1

  [
-   anyString(),
+   12345,
  ]
```

Instead of the raw object `{ mockit__any: true, what: "string" }`.

### 3. Closest call detection

When multiple calls exist, the error shows the closest matches (sorted by mismatch count).

### 4. Circular reference handling

No more stack overflow on circular objects.

### 5. Undefined = absent key

`{ a: 1 }` now matches `{ a: 1, b: undefined }` (bidirectional).

## API

```ts
// Default: shows 3 closest calls with diff
verifyThat(mock).wasCalledWith(args);

// Verbose: shows all calls
verifyThat(mock, { verbose: true }).wasCalledWith(args);
```

## Technical

New modular architecture in `src/argsComparisons/compare-v2/`:
- `comparators/` - one per value type (primitive, object, array, map, set)
- `matchers/` - handlers for mockit matchers
- `formatters/` - structured + visual diff (jest-diff + pretty-format)

Backwards compatible: `compare(a, b): boolean` still works.
