### PR TITLE
feat: add thenXxxOnce chainable methods to when().isCalled

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -6,7 +6,9 @@
       "Bash(find:*)",
       "Bash(cat:*)",
       "Bash(npx tsc:*)",
-      "Bash(npm test:*)"
+      "Bash(npm test:*)",
+      "Bash(pnpm build:*)",
+      "Bash(pnpm lint:*)"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -8,7 +8,8 @@
       "Bash(npx tsc:*)",
       "Bash(npm test:*)",
       "Bash(pnpm build:*)",
-      "Bash(pnpm lint:*)"
+      "Bash(pnpm lint:*)",
+      "Bash(gh pr view:*)"
     ]
   }
 }

--- a/src/__tests__/behaviours/once-behaviours.spec.ts
+++ b/src/__tests__/behaviours/once-behaviours.spec.ts
@@ -1,0 +1,163 @@
+import { Mock, when } from "../..";
+
+function returnNumber(n?: number): number {
+  return n ?? 42;
+}
+
+function asyncFunction(): Promise<number> {
+  return Promise.resolve(42);
+}
+
+describe("once behaviours", () => {
+  describe("thenReturnOnce", () => {
+    it("should return the value once then fallback to default", () => {
+      const mock = Mock(returnNumber);
+      when(mock).isCalled.thenReturnOnce(1);
+
+      expect(mock()).toBe(1);
+      expect(mock()).toBe(undefined); // default
+    });
+
+    it("should support chaining multiple thenReturnOnce (FIFO)", () => {
+      const mock = Mock(returnNumber);
+      when(mock).isCalled.thenReturnOnce(1).thenReturnOnce(2).thenReturnOnce(3);
+
+      expect(mock()).toBe(1);
+      expect(mock()).toBe(2);
+      expect(mock()).toBe(3);
+      expect(mock()).toBe(undefined); // default
+    });
+
+    it("should work with explicit fallback via thenReturn", () => {
+      const mock = Mock(returnNumber);
+      when(mock)
+        .isCalled.thenReturnOnce(1)
+        .thenReturnOnce(2)
+        .thenReturn(99); // fallback
+
+      expect(mock()).toBe(1);
+      expect(mock()).toBe(2);
+      expect(mock()).toBe(99); // fallback
+      expect(mock()).toBe(99); // still fallback
+    });
+  });
+
+  describe("thenThrowOnce", () => {
+    it("should throw once then fallback to default", () => {
+      const mock = Mock(returnNumber);
+      when(mock).isCalled.thenThrowOnce(new Error("oops")).thenReturn(99);
+
+      expect(() => mock()).toThrow("oops");
+      expect(mock()).toBe(99);
+    });
+
+    it("should support chaining thenThrowOnce with thenReturnOnce", () => {
+      const mock = Mock(returnNumber);
+      when(mock)
+        .isCalled.thenReturnOnce(1)
+        .thenThrowOnce(new Error("oops"))
+        .thenReturnOnce(3);
+
+      expect(mock()).toBe(1);
+      expect(() => mock()).toThrow("oops");
+      expect(mock()).toBe(3);
+    });
+  });
+
+  describe("thenResolveOnce", () => {
+    it("should resolve once then fallback to default", async () => {
+      const mock = Mock(asyncFunction);
+      when(mock).isCalled.thenResolveOnce(100).thenResolve(200);
+
+      await expect(mock()).resolves.toBe(100);
+      await expect(mock()).resolves.toBe(200);
+      await expect(mock()).resolves.toBe(200); // still fallback
+    });
+  });
+
+  describe("thenRejectOnce", () => {
+    it("should reject once then fallback to default", async () => {
+      const mock = Mock(asyncFunction);
+      when(mock).isCalled.thenRejectOnce(new Error("rejected")).thenResolve(200);
+
+      await expect(mock()).rejects.toThrow("rejected");
+      await expect(mock()).resolves.toBe(200);
+    });
+  });
+
+  describe("thenBehaveLikeOnce", () => {
+    it("should call custom function once then fallback", () => {
+      const mock = Mock(returnNumber);
+      let callCount = 0;
+      when(mock)
+        .isCalled.thenBehaveLikeOnce(() => {
+          callCount++;
+          return 999;
+        })
+        .thenReturn(100);
+
+      expect(mock()).toBe(999);
+      expect(callCount).toBe(1);
+      expect(mock()).toBe(100);
+      expect(callCount).toBe(1); // not called again
+    });
+  });
+
+  describe("thenPreserveOnce", () => {
+    it("should call original function once then fallback", () => {
+      const mock = Mock(returnNumber);
+      when(mock).isCalled.thenPreserveOnce().thenReturn(100);
+
+      expect(mock()).toBe(42); // original value
+      expect(mock()).toBe(100); // fallback
+    });
+  });
+
+  describe("mixed once behaviours", () => {
+    it("should support mixing different once behaviour types", () => {
+      const mock = Mock(returnNumber);
+      when(mock)
+        .isCalled.thenReturnOnce(1)
+        .thenThrowOnce(new Error("error"))
+        .thenPreserveOnce()
+        .thenReturn(99);
+
+      expect(mock()).toBe(1);
+      expect(() => mock()).toThrow("error");
+      expect(mock()).toBe(42); // preserved original
+      expect(mock()).toBe(99); // fallback
+    });
+  });
+
+  describe("backwards compatibility", () => {
+    it("should not break existing code without chaining", () => {
+      const mock = Mock(returnNumber);
+      when(mock).isCalled.thenReturn(999);
+      expect(mock()).toBe(999);
+    });
+
+    it("should work with isCalledWith alongside once behaviours", () => {
+      const mock = Mock(returnNumber);
+      when(mock).isCalled.thenReturnOnce(1).thenReturn(99);
+      when(mock).isCalledWith(42).thenReturn(777);
+
+      // Once behaviour takes priority over customBehaviour
+      expect(mock(42)).toBe(1);
+      // After once consumed, customBehaviour is checked
+      expect(mock(42)).toBe(777);
+      // For other args, fallback to default
+      expect(mock()).toBe(99);
+    });
+  });
+
+  describe("chaining default behaviours", () => {
+    it("should support chaining default behaviours (last one wins)", () => {
+      const mock = Mock(returnNumber);
+      when(mock).isCalled.thenReturn(1).thenReturn(2);
+
+      // Last thenReturn wins
+      expect(mock()).toBe(2);
+      expect(mock()).toBe(2);
+    });
+  });
+});

--- a/src/behaviours/when.ts
+++ b/src/behaviours/when.ts
@@ -1,47 +1,124 @@
-import { AllowZodSchemas } from "../types";
 import { Behaviours } from "./behaviours";
+
+/**
+ * Interface for the chainable isCalled API.
+ * All methods return the API itself for chaining.
+ */
+interface IsCalledApi<TFunc extends (...args: any[]) => any> {
+  // Default behaviours
+  thenReturn(value: ReturnType<TFunc>): IsCalledApi<TFunc>;
+  thenThrow(error: any): IsCalledApi<TFunc>;
+  thenResolve(resolvedValue: Awaited<ReturnType<TFunc>>): IsCalledApi<TFunc>;
+  thenReject(rejectedValue: any): IsCalledApi<TFunc>;
+  thenBehaveLike(fn: (...args: Parameters<TFunc>) => any): IsCalledApi<TFunc>;
+  thenPreserve(): IsCalledApi<TFunc>;
+
+  // Once behaviours (FIFO queue)
+  thenReturnOnce(value: ReturnType<TFunc>): IsCalledApi<TFunc>;
+  thenThrowOnce(error: any): IsCalledApi<TFunc>;
+  thenResolveOnce(
+    resolvedValue: Awaited<ReturnType<TFunc>>
+  ): IsCalledApi<TFunc>;
+  thenRejectOnce(rejectedValue: any): IsCalledApi<TFunc>;
+  thenBehaveLikeOnce(
+    fn: (...args: Parameters<TFunc>) => any
+  ): IsCalledApi<TFunc>;
+  thenPreserveOnce(): IsCalledApi<TFunc>;
+}
 
 export function when<TFunc extends (...args: any[]) => any>(
   mockedFunction: TFunc
 ) {
-  return {
-    isCalled: {
-      thenReturn: (value: ReturnType<TFunc>) => {
-        Reflect.set(mockedFunction, "defaultBehaviour", {
-          kind: Behaviours.Return,
-          returnedValue: value,
-        });
-      },
-      thenPreserve: () => {
-        Reflect.set(mockedFunction, "defaultBehaviour", {
-          kind: Behaviours.Preserve,
-        });
-      },
-      thenThrow: (error: any) => {
-        Reflect.set(mockedFunction, "defaultBehaviour", {
-          kind: Behaviours.Throw,
-          error,
-        });
-      },
-      thenResolve: (resolvedValue: Awaited<ReturnType<TFunc>>) => {
-        Reflect.set(mockedFunction, "defaultBehaviour", {
-          kind: Behaviours.Resolve,
-          resolvedValue,
-        });
-      },
-      thenBehaveLike(customBehaviour: (...args: Parameters<TFunc>) => any) {
-        Reflect.set(mockedFunction, "defaultBehaviour", {
-          kind: Behaviours.Custom,
-          customBehaviour,
-        });
-      },
-      thenReject: (rejectedValue: any) => {
-        Reflect.set(mockedFunction, "defaultBehaviour", {
-          kind: Behaviours.Reject,
-          rejectedValue,
-        });
-      },
+  const isCalledApi: IsCalledApi<TFunc> = {
+    // Default behaviours
+    thenReturn(value: ReturnType<TFunc>) {
+      Reflect.set(mockedFunction, "defaultBehaviour", {
+        kind: Behaviours.Return,
+        returnedValue: value,
+      });
+      return isCalledApi;
     },
+    thenThrow(error: any) {
+      Reflect.set(mockedFunction, "defaultBehaviour", {
+        kind: Behaviours.Throw,
+        error,
+      });
+      return isCalledApi;
+    },
+    thenResolve(resolvedValue: Awaited<ReturnType<TFunc>>) {
+      Reflect.set(mockedFunction, "defaultBehaviour", {
+        kind: Behaviours.Resolve,
+        resolvedValue,
+      });
+      return isCalledApi;
+    },
+    thenReject(rejectedValue: any) {
+      Reflect.set(mockedFunction, "defaultBehaviour", {
+        kind: Behaviours.Reject,
+        rejectedValue,
+      });
+      return isCalledApi;
+    },
+    thenBehaveLike(customBehaviour: (...args: Parameters<TFunc>) => any) {
+      Reflect.set(mockedFunction, "defaultBehaviour", {
+        kind: Behaviours.Custom,
+        customBehaviour,
+      });
+      return isCalledApi;
+    },
+    thenPreserve() {
+      Reflect.set(mockedFunction, "defaultBehaviour", {
+        kind: Behaviours.Preserve,
+      });
+      return isCalledApi;
+    },
+
+    // Once behaviours (FIFO queue)
+    thenReturnOnce(value: ReturnType<TFunc>) {
+      Reflect.set(mockedFunction, "newOnceBehaviour", {
+        kind: Behaviours.Return,
+        returnedValue: value,
+      });
+      return isCalledApi;
+    },
+    thenThrowOnce(error: any) {
+      Reflect.set(mockedFunction, "newOnceBehaviour", {
+        kind: Behaviours.Throw,
+        error,
+      });
+      return isCalledApi;
+    },
+    thenResolveOnce(resolvedValue: Awaited<ReturnType<TFunc>>) {
+      Reflect.set(mockedFunction, "newOnceBehaviour", {
+        kind: Behaviours.Resolve,
+        resolvedValue,
+      });
+      return isCalledApi;
+    },
+    thenRejectOnce(rejectedValue: any) {
+      Reflect.set(mockedFunction, "newOnceBehaviour", {
+        kind: Behaviours.Reject,
+        rejectedValue,
+      });
+      return isCalledApi;
+    },
+    thenBehaveLikeOnce(customBehaviour: (...args: Parameters<TFunc>) => any) {
+      Reflect.set(mockedFunction, "newOnceBehaviour", {
+        kind: Behaviours.Custom,
+        customBehaviour,
+      });
+      return isCalledApi;
+    },
+    thenPreserveOnce() {
+      Reflect.set(mockedFunction, "newOnceBehaviour", {
+        kind: Behaviours.Preserve,
+      });
+      return isCalledApi;
+    },
+  };
+
+  return {
+    isCalled: isCalledApi,
     isCalledWith(...args: Parameters<TFunc>) {
       return {
         thenReturn: (value: ReturnType<TFunc>) => {

--- a/src/mocks/mockFunction.ts
+++ b/src/mocks/mockFunction.ts
@@ -271,6 +271,11 @@ export function mockFunction<T extends (...args: any[]) => any>(
         return true;
       }
 
+      if (prop === "newOnceBehaviour") {
+        onceBehaviours.push(value as NewBehaviourParam<T>);
+        return true;
+      }
+
       if (prop === "resetBehaviourOf") {
         customBehaviours.length = 0;
         onceBehaviours.length = 0;


### PR DESCRIPTION
## Summary

Adds chainable `thenXxxOnce` methods to the BDD-style `when().isCalled` API, bringing feature parity with the Jest-style `mockReturnValueOnce` etc. methods.

## Motivation

The Jest-style API already supports once-behaviors via `mockReturnValueOnce()` etc. This PR adds the same capability to the BDD-style `when().isCalled` API for developers who prefer that syntax.

## New Features

### Chainable once-behaviors on `when().isCalled`

```ts
when(mock).isCalled
  .thenReturnOnce(1)
  .thenReturnOnce(2)
  .thenThrowOnce(new Error("oops"))
  .thenReturn(99);  // fallback

mock(); // 1
mock(); // 2
mock(); // throws "oops"
mock(); // 99 (fallback from now on)
```

### New methods
- `thenReturnOnce(value)`
- `thenThrowOnce(error)`
- `thenResolveOnce(value)`
- `thenRejectOnce(error)`
- `thenBehaveLikeOnce(fn)`
- `thenPreserveOnce()`

### Chaining support
All `isCalled` methods now return the API itself, enabling chaining:

```ts
when(mock).isCalled
  .thenReturnOnce(1)
  .thenReturnOnce(2)
  .thenReturn(99);
```

## Backwards Compatibility

Existing code continues to work unchanged. This PR only adds new methods and makes existing methods chainable.