### PR TITLE
feature: stub aliases & integration with Mock function to allow inline partial mocking.

### DIFF
--- a/src/__tests__/inline-api/mock.partial.spec.ts
+++ b/src/__tests__/inline-api/mock.partial.spec.ts
@@ -84,3 +84,10 @@ test("mocking only get", () => {
   
   expect(sut(mock2)).toBeUndefined();
 });
+
+test("should allow extracting a function mock", () => {
+  const getUser = m.fn((id) => "User 1");
+  expect(sut(m.Mock<UserRepository>({ getUser }))).toBeUndefined();
+  
+  m.verifyThat(getUser).wasCalledWith(1);
+});

--- a/src/__tests__/inline-api/mock.partial.spec.ts
+++ b/src/__tests__/inline-api/mock.partial.spec.ts
@@ -1,0 +1,53 @@
+import { m } from "../..";
+
+interface Book {
+    id: string;
+    title: string;
+    author: string;
+    publishedAt: Date;
+    isArchived: boolean;
+}
+
+interface BookRepository {
+    getBook(id: string): Promise<Book>;
+    isBookNameAvailable(name: string): Promise<{ isAvailable: false; id: string } | { isAvailable: true }>;
+    saveBook(book: Book): Promise<void>;
+    deleteBook(id: string): Promise<void>;
+    archiveBook(id: string): Promise<void>;
+    restoreBook(id: string): Promise<void>;
+    unarchiveBook(id: string): Promise<void>;
+}
+
+async function registerBook(bookName: string, bookRepository: BookRepository) {
+    const existingBook = await bookRepository.isBookNameAvailable(bookName);
+    if (!existingBook.isAvailable) {
+        return { isAvailable: false };
+    }
+
+    const newBook = {
+        id: crypto.randomUUID(),
+        title: bookName,
+        author: "to define",
+        publishedAt: new Date(),
+        isArchived: false,
+    }
+
+    await bookRepository.saveBook(newBook);
+
+    return { isAvailable: true, id: newBook.id };
+}
+
+it("should allow to setup a partial mock inline", async () => {
+    const response = await registerBook("The Greate Gatsby", m.Mock({
+        isBookNameAvailable: m.resolves({ isAvailable: false, id: "123" })
+    }));
+    expect(response).toEqual({ isAvailable: false });
+});
+
+it("should allow several setups", async () => {
+    const response = await registerBook("The Greate Gatsby", m.Mock({
+        isBookNameAvailable: m.resolves({ isAvailable: true }),
+        saveBook: m.resolves(undefined),
+    }));
+    expect(response).toEqual({ isAvailable: true, id: expect.any(String) });
+});

--- a/src/__tests__/inline-api/mock.partial.spec.ts
+++ b/src/__tests__/inline-api/mock.partial.spec.ts
@@ -51,3 +51,12 @@ it("should allow several setups", async () => {
     }));
     expect(response).toEqual({ isAvailable: true, id: expect.any(String) });
 });
+
+it("should stub the methods automatically if not provided", async () => {
+    const response = await registerBook("The Greate Gatsby", m.Mock({
+        isBookNameAvailable: m.resolves({ isAvailable: true }),
+    }));
+    expect(response).toEqual({ isAvailable: true, id: expect.any(String) });
+    // To explain, above should only be possible if repository.saveBook is stubbed. Otherwise it would throw an error
+    // because sut is trying to call the method => it can only work if it's been auto stubbed.
+});

--- a/src/__tests__/inline-api/mock.partial.spec.ts
+++ b/src/__tests__/inline-api/mock.partial.spec.ts
@@ -60,3 +60,27 @@ it("should stub the methods automatically if not provided", async () => {
     // To explain, above should only be possible if repository.saveBook is stubbed. Otherwise it would throw an error
     // because sut is trying to call the method => it can only work if it's been auto stubbed.
 });
+
+
+interface UserRepository {
+  getUser: (id: number) => string;
+  saveUser: (user: { id: number; name: string }) => void;
+}
+
+function sut(userRepository: UserRepository) {
+  userRepository.getUser(1);
+  userRepository.saveUser({ id: 1, name: "John" });
+}
+
+test("mocking only get", () => {
+
+  expect(sut(m.Mock({
+    getUser: m.returns("User 1"),
+  }))).toBeUndefined();
+
+  const mock2 = m.Mock<UserRepository>({
+    getUser: m.returns("User 1"),
+  });
+  
+  expect(sut(mock2)).toBeUndefined();
+});

--- a/src/__tests__/stubs/aliases.spec.ts
+++ b/src/__tests__/stubs/aliases.spec.ts
@@ -1,0 +1,41 @@
+import { m } from "../..";
+
+function returnsSomething(x: string): string {
+    return `${x} something`;
+}
+
+function resolvesSomething(x: string): Promise<string> {
+    return Promise.resolve(`${x} something`);
+}
+
+function sut(x: string, rs: typeof returnsSomething) {
+    return rs(x);
+}
+
+it("should pass types or generate errors, and control the basic behaviours", () => {
+    expect(sut("hello", m.returns("23"))).toBe("23");
+    // @ts-expect-error - function should not return (it's synchronous). This expect error is a type check !
+    expect(sut("hello", m.resolves("23"))).resolves.toBe("23");
+    // @ts-expect-error - function should not reject (it's synchronous). This expect error is a type check !
+    expect(sut("hello", m.rejects(new Error("23")))).rejects.toThrow("23");
+    expect(() => sut("hello", m.throws(new Error("23")))).toThrow("23");
+});
+
+async function sutAsync(x: string, rs: typeof resolvesSomething) {
+    return rs(x);
+}
+
+it("should do it asynchronously", async () => {
+    expect(sutAsync("hello", m.resolves("23"))).resolves.toBe("23");
+    expect(sutAsync("hello", m.rejects(new Error("23")))).rejects.toThrow("23");
+    expect(sutAsync("hello", m.throws(new Error("23")))).rejects.toThrow("23");
+    // @ts-expect-error - function should not return (it's asynchronous). This expect error is a type check !
+    expect(await sutAsync("hello", m.returns("23"))).toBe("23");
+    // here it's presented as a promise, so types should pass !
+    expect(sutAsync("hello", m.returns(new Promise((resolve) => resolve("23"))))).resolves.toBe("23");
+});
+
+
+
+
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,8 +11,8 @@ export type {
   MockFunctionMethods,
 } from "./types";
 
-import { Mock, fn } from "./mocks/Mock";
+import { Mock, fn, stubReturning, stubThrowing, stubResolving, stubRejecting } from "./mocks/Mock";
 import * as resets from "./mocks/mockFunction.reset";
 import * as verifications from "./assertions";
 import { when } from "./behaviours";
-export const m = { ...matchers, ...resets, ...verifications, when, Mock, fn };
+export const m = { ...matchers, ...resets, ...verifications, when, Mock, fn, returns: stubReturning, throws: stubThrowing, resolves: stubResolving, rejects: stubRejecting };

--- a/src/mocks/Mock.ts
+++ b/src/mocks/Mock.ts
@@ -72,7 +72,7 @@ export function Mock<T>(classRef: Class<T> | AbstractClass<T>, partial?: Partial
  * const mock = Mock({ getUser: () => user });
  * ```
  */
-export function Mock<T extends object>(obj: NoInfer<T>): MockedObject<T>;
+export function Mock<T extends object>(obj: T): MockedObject<T>;
 
 /**
  * Creates a mock from a type/interface.

--- a/src/mocks/Mock.ts
+++ b/src/mocks/Mock.ts
@@ -27,6 +27,22 @@ export function fn<T extends (...args: any[]) => any = (...args: any[]) => any>(
   return mock;
 }
 
+export function stubReturning<T>(value: T): () => T {
+  return fn().mockReturnValue(value);
+}
+
+export function stubThrowing<T>(error: any): () => T {
+  return fn().mockThrow(error);
+}
+
+export function stubResolving<T>(value: T): () => Promise<T> {
+  return fn().mockResolvedValue(value);
+}
+
+export function stubRejecting<T>(error: any): () => Promise<T> {
+  return fn().mockRejectedValue(error);
+}
+
 /**
  * Creates a mock of a function.
  * @example
@@ -46,7 +62,7 @@ export function Mock<T extends (...args: any[]) => any>(
  * const mock = Mock(UserService);
  * ```
  */
-export function Mock<T>(classRef: Class<T> | AbstractClass<T>): MockedObject<T>;
+export function Mock<T>(classRef: Class<T> | AbstractClass<T>, partial?: Partial<T>): MockedObject<T>;
 
 /**
  * Creates a mock from a plain object.
@@ -64,7 +80,7 @@ export function Mock<T extends object>(obj: T): MockedObject<T>;
  * const mock = Mock<UserService>();
  * ```
  */
-export function Mock<T>(): MockedObject<T>;
+export function Mock<T>(partial?: Partial<T>): MockedObject<T>;
 
 /**
  * Implementation that handles all overloads.
@@ -93,7 +109,20 @@ export function Mock<T>(_param?: any): T {
 function ProxyMockBase<T>(
   _param: Class<T> | AbstractClass<T> | T | void = undefined
 ): T {
-  return new Proxy({} as any, {
+  const target: any = {};
+
+  // If _param is a plain object, only copy properties that are already mock functions
+  // This allows Mock<Type>({ get: m.resolves(42) }) while keeping Mock(realObject) behavior
+  if (_param && typeof _param === "object") {
+    for (const key of Object.keys(_param)) {
+      const value = (_param as any)[key];
+      if (value && value.isMockitMock) {
+        target[key] = value;
+      }
+    }
+  }
+
+  return new Proxy(target, {
     get(target, prop, receiver) {
       if (prop in target) {
         return Reflect.get(target, prop, receiver);

--- a/src/mocks/Mock.ts
+++ b/src/mocks/Mock.ts
@@ -2,6 +2,7 @@ import { AbstractClass, Class } from "../types";
 import { mockFunction } from "./mockFunction";
 import { resetBehaviourOf, resetHistoryOf } from "./mockFunction.reset";
 import { MockedFunction, MockedObject } from "../types/inline-api.types";
+import { NoInfer } from "../behaviours/matchers";
 
 /**
  * Creates a standalone mock function, similar to jest.fn().
@@ -62,7 +63,7 @@ export function Mock<T extends (...args: any[]) => any>(
  * const mock = Mock(UserService);
  * ```
  */
-export function Mock<T>(classRef: Class<T> | AbstractClass<T>, partial?: Partial<T>): MockedObject<T>;
+export function Mock<T>(classRef: Class<T> | AbstractClass<T>, partial?: Partial<NoInfer<T>>): MockedObject<T>;
 
 /**
  * Creates a mock from a plain object.
@@ -71,7 +72,7 @@ export function Mock<T>(classRef: Class<T> | AbstractClass<T>, partial?: Partial
  * const mock = Mock({ getUser: () => user });
  * ```
  */
-export function Mock<T extends object>(obj: T): MockedObject<T>;
+export function Mock<T extends object>(obj: NoInfer<T>): MockedObject<T>;
 
 /**
  * Creates a mock from a type/interface.
@@ -80,7 +81,7 @@ export function Mock<T extends object>(obj: T): MockedObject<T>;
  * const mock = Mock<UserService>();
  * ```
  */
-export function Mock<T>(partial?: Partial<T>): MockedObject<T>;
+export function Mock<T>(partial?: Partial<NoInfer<T>>): MockedObject<T>;
 
 /**
  * Implementation that handles all overloads.


### PR DESCRIPTION
In this PR, I added syntactic sugars for inline stubs. The main objective is to allow the creation of very precise mocking in as little characters as possible.

### Stub aliases.
```
(m.returns(42))(); // 42
(m.throws("yo"))() // throws "yo"
(m.rejects("yo"))() // rejects "yo"
(m.resolves("42"))() // resolves 42.
```

How should this be used ?
Here's a dumb implementation of a book registration in an editor's system. It checks several factors before saving the book, and will save a new author if he never wrote anything for the editor:

```ts
interface Book {
  authorID: string;
  title: string;
  createdAt: string;
  status: "draft" | "review" | "published";
}

interface BookRepository {
  isTitleTaken(title: string): Promise<boolean>;
  createDraft(book: Book): Promise<void>;
}

interface Author {
  name: string;
  id: string;
}

interface AuthorRepository {
  doesAuthorExist(name: string): Promise<{ exists: true; id: string } | { exists: false }>;
  createAuthor(author: Author): Promise<boolean>;
}

async function registerBook(
  params: { bookTitle: string; authorName: string },
  deps: { bookRepository: BookRepository; authorRepository: AuthorRepository }
) {
  const bookTitleTaken = await deps.bookRepository.isTitleTaken(params.bookTitle);
  if (bookTitleTaken) throw new Errors.Domain("Book name unaivailable. Choose another one");
  
  const author = await deps.authorRepository.doesAuthorExist(params.authorName);
  let authorID: string;
  if (!author.exists) {
    authorID = crypto.randomUUID();
    await deps.authorRepository.createAuthor({ id: authorID, name: params.authorName });
  } else {
    authorID = author.id;
  }

  await deps.bookRepository.createDraft({
    id: crypto.randomUUID(),
    authorID, name: params.bookName,
    state: "draft";
    createdAt:  Date.now()
  });
}

```

To test this with mockit before, you had to create mocks, assign behaviour, and then call the function. Like so

```ts
// API 1 - mockito style
const bookRepo = m.Mock<BookRepository>();
m.when(bookRepo.isTitleTaken).isCalled.thenResolve(false);
m.when(bookRepo.createDraft).isCalled.thenResolve(undefined);
const authorRepo = m.Mock<AuthorRepository>();
m.when(authorRepo.doesAuthorExist).isCalled.thenResolve({ exists: false });
m.when(authorRepo.createAuthor).isCalled.thenResolve(true);

registerBook({ bookTitle: "The Great Gatsby", authorName: "F. Scott Fitzgerald" }, { bookRepo, authorRepo });

// API 2 - jest-style
const bookRepo = m.Mock<BookRepository>();
bookRepo.isTitleTaken.mockResolvedValue(false);
bookRepo.createDraft.mockResolvedValue(undefined);
const authorRepo = m.Mock<AuthorRepository>();
authorRepo.doesAuthorExist.mockResolvedValue({ exists: false });
authorRepo.createAuthor.mockResolvedValue(true);

registerBook({ bookTitle: "The Great Gatsby", authorName: "F. Scott Fitzgerald" }, { bookRepo, authorRepo });

// API 3 - inline-style
registerBook({ bookTitle: "The Great Gatsby", authorName: "F. Scott Fitzgerald" }, {
    bookRepo: m.Mock({
        isTitleTaken: m.resolves(false),
        createDraft: m.resolves(undefined),
    }),
    authorRepo: m.Mock({
        doesAuthorExist: m.resolves({ exists: false }),
        createAuthor: m.resolves(true),
    }),
});
```

Main advantage: if you do not wish to check the behaviour of the mock (via a `verifyThat` call), which can be fragile and a bit tedious, then the inline API does not require importing the interfaces. Inlined `m.Mock` automatically locks the correct interface in its generic slot, and will provide type-safety.

You can still check this behaviour by extracting one of the function, but that will require using the interface of the mock you're extracting the function from:

```ts
const isTitleTaken = m.fn((title: string) => false);

registerBook({ bookTitle: "The Great Gatsby", authorName: "F. Scott Fitzgerald" }, {
    // needed here
    bookRepo: m.Mock<BookRepository>({
        isTitleTaken,
        createDraft: m.resolves(undefined),
    }),
    // not needed here
    authorRepo: m.Mock({
        doesAuthorExist: m.resolves({ exists: false }),
        createAuthor: m.resolves(true),
    }),
});

verifyThat(isTitleTaken).wasCalledWith("The Great Gatsby");
```

