### PR TITLE
feature: introduce MockStrict

### DIFF
--- a/src/__tests__/inline-api/strict-mock.spec.ts
+++ b/src/__tests__/inline-api/strict-mock.spec.ts
@@ -1,4 +1,4 @@
-import { StrictMock, m } from "../../index";
+import { MockStrict, m } from "../../index";
 
 interface UserService {
   getUser(id: number): { id: number; name: string };
@@ -14,22 +14,22 @@ class UserServiceClass {
   }
 }
 
-describe("StrictMock", () => {
+describe("MockStrict", () => {
   describe("with interface mock", () => {
     it("throws when an unconfigured method is called", () => {
-      const mock = StrictMock<UserService>();
+      const mock = MockStrict<UserService>();
 
       expect(() => mock.getUser(1)).toThrow("No behavior configured for 'getUser'");
     });
 
     it("includes the method name in the error message", () => {
-      const mock = StrictMock<UserService>();
+      const mock = MockStrict<UserService>();
 
       expect(() => mock.deleteUser(1)).toThrow("No behavior configured for 'deleteUser'");
     });
 
     it("works normally when the method is configured", () => {
-      const mock = StrictMock<UserService>();
+      const mock = MockStrict<UserService>();
       mock.getUser.mockReturnValue({ id: 1, name: "Test User" });
 
       const result = mock.getUser(1);
@@ -38,7 +38,7 @@ describe("StrictMock", () => {
     });
 
     it("works with partial configuration", () => {
-      const mock = StrictMock<UserService>({
+      const mock = MockStrict<UserService>({
         getUser: m.returns({ id: 42, name: "Configured User" }),
       });
 
@@ -49,13 +49,13 @@ describe("StrictMock", () => {
 
   describe("with class mock", () => {
     it("throws when an unconfigured method is called", () => {
-      const mock = StrictMock(UserServiceClass);
+      const mock = MockStrict(UserServiceClass);
 
       expect(() => mock.getUser(1)).toThrow("No behavior configured for 'getUser'");
     });
 
     it("works normally when the method is configured", () => {
-      const mock = StrictMock(UserServiceClass);
+      const mock = MockStrict(UserServiceClass);
       mock.getUser.mockReturnValue({ id: 1, name: "Test User" });
 
       const result = mock.getUser(1);
@@ -67,23 +67,23 @@ describe("StrictMock", () => {
   describe("with function mock", () => {
     it("throws when called without configuration", () => {
       const fn = (x: number) => x * 2;
-      const mock = StrictMock(fn);
+      const mock = MockStrict(fn);
 
       expect(() => mock(5)).toThrow("No behavior configured");
     });
 
     it("works normally when configured", () => {
       const fn = (x: number) => x * 2;
-      const mock = StrictMock(fn);
+      const mock = MockStrict(fn);
       mock.mockReturnValue(100);
 
       expect(mock(5)).toBe(100);
     });
   });
 
-  describe("accessible via m.StrictMock", () => {
+  describe("accessible via m.MockStrict", () => {
     it("is available on the m namespace", () => {
-      const mock = m.StrictMock<UserService>();
+      const mock = m.MockStrict<UserService>();
 
       expect(() => mock.getUser(1)).toThrow("No behavior configured for 'getUser'");
     });

--- a/src/__tests__/inline-api/strict-mock.spec.ts
+++ b/src/__tests__/inline-api/strict-mock.spec.ts
@@ -1,0 +1,91 @@
+import { StrictMock, m } from "../../index";
+
+interface UserService {
+  getUser(id: number): { id: number; name: string };
+  deleteUser(id: number): void;
+}
+
+class UserServiceClass {
+  getUser(id: number): { id: number; name: string } {
+    return { id, name: "Real User" };
+  }
+  deleteUser(id: number): void {
+    console.log(`Deleting user ${id}`);
+  }
+}
+
+describe("StrictMock", () => {
+  describe("with interface mock", () => {
+    it("throws when an unconfigured method is called", () => {
+      const mock = StrictMock<UserService>();
+
+      expect(() => mock.getUser(1)).toThrow("No behavior configured for 'getUser'");
+    });
+
+    it("includes the method name in the error message", () => {
+      const mock = StrictMock<UserService>();
+
+      expect(() => mock.deleteUser(1)).toThrow("No behavior configured for 'deleteUser'");
+    });
+
+    it("works normally when the method is configured", () => {
+      const mock = StrictMock<UserService>();
+      mock.getUser.mockReturnValue({ id: 1, name: "Test User" });
+
+      const result = mock.getUser(1);
+
+      expect(result).toEqual({ id: 1, name: "Test User" });
+    });
+
+    it("works with partial configuration", () => {
+      const mock = StrictMock<UserService>({
+        getUser: m.returns({ id: 42, name: "Configured User" }),
+      });
+
+      expect(mock.getUser(1)).toEqual({ id: 42, name: "Configured User" });
+      expect(() => mock.deleteUser(1)).toThrow("No behavior configured for 'deleteUser'");
+    });
+  });
+
+  describe("with class mock", () => {
+    it("throws when an unconfigured method is called", () => {
+      const mock = StrictMock(UserServiceClass);
+
+      expect(() => mock.getUser(1)).toThrow("No behavior configured for 'getUser'");
+    });
+
+    it("works normally when the method is configured", () => {
+      const mock = StrictMock(UserServiceClass);
+      mock.getUser.mockReturnValue({ id: 1, name: "Test User" });
+
+      const result = mock.getUser(1);
+
+      expect(result).toEqual({ id: 1, name: "Test User" });
+    });
+  });
+
+  describe("with function mock", () => {
+    it("throws when called without configuration", () => {
+      const fn = (x: number) => x * 2;
+      const mock = StrictMock(fn);
+
+      expect(() => mock(5)).toThrow("No behavior configured");
+    });
+
+    it("works normally when configured", () => {
+      const fn = (x: number) => x * 2;
+      const mock = StrictMock(fn);
+      mock.mockReturnValue(100);
+
+      expect(mock(5)).toBe(100);
+    });
+  });
+
+  describe("accessible via m.StrictMock", () => {
+    it("is available on the m namespace", () => {
+      const mock = m.StrictMock<UserService>();
+
+      expect(() => mock.getUser(1)).toThrow("No behavior configured for 'getUser'");
+    });
+  });
+});

--- a/src/__tests__/mockType/mock_types.ts
+++ b/src/__tests__/mockType/mock_types.ts
@@ -1,4 +1,4 @@
-import { getMockHistory, verifyThat } from "../../assertions";
+import { verifyThat } from "../../assertions";
 import { when } from "../../behaviours";
 import { Mock } from "../..";
 

--- a/src/__tests__/spy/basic.spec.ts
+++ b/src/__tests__/spy/basic.spec.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
-import { Mock, getMockHistory, m } from "../..";
+import { Mock, m } from "../..";
+import { getMockHistory } from "../../assertions";
 
 test("spied function should give access to its calls", () => {
   const mock = Mock((x: number, y: string) => {});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export { Mock, fn, MockStrict } from "./mocks/Mock";
 export { when } from "./behaviours";
-export { getMockHistory, verifyThat } from "./assertions";
+export { verifyThat } from "./assertions";
 export { resetBehaviourOf, resetCompletely, resetHistoryOf } from "./mocks";
 import * as matchers from "./behaviours/matchers";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { Mock, fn, StrictMock } from "./mocks/Mock";
+export { Mock, fn, MockStrict } from "./mocks/Mock";
 export { when } from "./behaviours";
 export { getMockHistory, verifyThat } from "./assertions";
 export { resetBehaviourOf, resetCompletely, resetHistoryOf } from "./mocks";
@@ -11,8 +11,8 @@ export type {
   MockFunctionMethods,
 } from "./types";
 
-import { Mock, fn, StrictMock, stubReturning, stubThrowing, stubResolving, stubRejecting } from "./mocks/Mock";
+import { Mock, fn, MockStrict, stubReturning, stubThrowing, stubResolving, stubRejecting } from "./mocks/Mock";
 import * as resets from "./mocks/mockFunction.reset";
-import * as verifications from "./assertions";
+import { verifyThat } from "./assertions";
 import { when } from "./behaviours";
-export const m = { ...matchers, ...resets, ...verifications, when, Mock, fn, StrictMock, returns: stubReturning, throws: stubThrowing, resolves: stubResolving, rejects: stubRejecting };
+export const m = { ...matchers, ...resets, verifyThat, when, Mock, fn, MockStrict, returns: stubReturning, throws: stubThrowing, resolves: stubResolving, rejects: stubRejecting };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { Mock, fn } from "./mocks/Mock";
+export { Mock, fn, StrictMock } from "./mocks/Mock";
 export { when } from "./behaviours";
 export { getMockHistory, verifyThat } from "./assertions";
 export { resetBehaviourOf, resetCompletely, resetHistoryOf } from "./mocks";
@@ -11,8 +11,8 @@ export type {
   MockFunctionMethods,
 } from "./types";
 
-import { Mock, fn, stubReturning, stubThrowing, stubResolving, stubRejecting } from "./mocks/Mock";
+import { Mock, fn, StrictMock, stubReturning, stubThrowing, stubResolving, stubRejecting } from "./mocks/Mock";
 import * as resets from "./mocks/mockFunction.reset";
 import * as verifications from "./assertions";
 import { when } from "./behaviours";
-export const m = { ...matchers, ...resets, ...verifications, when, Mock, fn, returns: stubReturning, throws: stubThrowing, resolves: stubResolving, rejects: stubRejecting };
+export const m = { ...matchers, ...resets, ...verifications, when, Mock, fn, StrictMock, returns: stubReturning, throws: stubThrowing, resolves: stubResolving, rejects: stubRejecting };

--- a/src/mocks/Mock.ts
+++ b/src/mocks/Mock.ts
@@ -198,53 +198,53 @@ function isClass(obj: Function) {
  * Creates a strict mock of a function that throws when called without configuration.
  * @example
  * ```ts
- * const fn = StrictMock(someFunc);
+ * const fn = MockStrict(someFunc);
  * fn(); // throws Error: "No behavior configured"
  * fn.mockReturnValue(42);
  * fn(); // returns 42
  * ```
  */
-export function StrictMock<T extends (...args: any[]) => any>(fn: T): MockedFunction<T>;
+export function MockStrict<T extends (...args: any[]) => any>(fn: T): MockedFunction<T>;
 
 /**
  * Creates a strict mock of a class that throws when unconfigured methods are called.
  * @example
  * ```ts
- * const mock = StrictMock(UserService);
+ * const mock = MockStrict(UserService);
  * mock.getUser(); // throws Error: "No behavior configured for 'getUser'"
  * ```
  */
-export function StrictMock<T>(classRef: Class<T> | AbstractClass<T>, partial?: Partial<NoInfer<T>>): MockedObject<T>;
+export function MockStrict<T>(classRef: Class<T> | AbstractClass<T>, partial?: Partial<NoInfer<T>>): MockedObject<T>;
 
 /**
  * Creates a strict mock from a plain object.
  * @example
  * ```ts
- * const mock = StrictMock({ getUser: () => user });
+ * const mock = MockStrict({ getUser: () => user });
  * ```
  */
-export function StrictMock<T extends object>(obj: T): MockedObject<T>;
+export function MockStrict<T extends object>(obj: T): MockedObject<T>;
 
 /**
  * Creates a strict mock from a type/interface that throws when unconfigured methods are called.
  * @example
  * ```ts
- * const mock = StrictMock<UserService>();
+ * const mock = MockStrict<UserService>();
  * mock.getUser(); // throws Error: "No behavior configured for 'getUser'"
  * ```
  */
-export function StrictMock<T>(partial?: Partial<NoInfer<T>>): MockedObject<T>;
+export function MockStrict<T>(partial?: Partial<NoInfer<T>>): MockedObject<T>;
 
 /**
  * Implementation that handles all overloads.
  */
-export function StrictMock<T>(_param?: any): T {
+export function MockStrict<T>(_param?: any): T {
   const strictBehaviourFactory: DefaultBehaviourFactory = (propertyName) => ({
     kind: Behaviours.Throw,
     error: new Error(`No behavior configured for '${propertyName}'`),
   });
 
-  // Case: StrictMock<Type>() - no arguments, create strict object mock
+  // Case: MockStrict<Type>() - no arguments, create strict object mock
   if (_param === undefined) {
     return ProxyMockBase<T>(undefined, { defaultBehaviourFactory: strictBehaviourFactory });
   }

--- a/src/mocks/index.ts
+++ b/src/mocks/index.ts
@@ -1,5 +1,5 @@
 export { mockFunction } from "./mockFunction";
-export { Mock, fn, StrictMock } from "./Mock";
+export { Mock, fn, MockStrict } from "./Mock";
 
 export {
   resetBehaviourOf,

--- a/src/mocks/index.ts
+++ b/src/mocks/index.ts
@@ -1,5 +1,5 @@
 export { mockFunction } from "./mockFunction";
-export { Mock, fn } from "./Mock";
+export { Mock, fn, StrictMock } from "./Mock";
 
 export {
   resetBehaviourOf,

--- a/src/tutorial/9-low-level-api_getMockHistory.spec.ts
+++ b/src/tutorial/9-low-level-api_getMockHistory.spec.ts
@@ -10,16 +10,17 @@ type UserRepository = {
 
 const userRepositoryMock = m.Mock<UserRepository>();
 
-test("I should access the raw history of a mock", () => {
+test("I should access the raw history of a mock via .calls", () => {
     userRepositoryMock.getUser(1);
     userRepositoryMock.getUser(2);
 
-    const history = m.getMockHistory(userRepositoryMock.getUser);
+    // Access call history directly via .calls property
+    const calls = userRepositoryMock.getUser.calls;
 
-    expect(history.getCalls()[0].args[0]).toBe(1);
-    expect(history.getCalls()[1].args[0]).toBe(2);
+    expect(calls[0].args[0]).toBe(1);
+    expect(calls[1].args[0]).toBe(2);
 
     // the calls are type-safe to help you explore the history of the mock
     // Uncomment the next line: it will not compile because the argument is expected to be a number
-    // history.getCalls()[0].args[0] === "Victor"
+    // calls[0].args[0] === "Victor"
 });


### PR DESCRIPTION
## Summary

- Introduce `MockStrict`, an alternative to `Mock` that throws when a method is called without configured behavior
- Remove `getMockHistory` from the public API (BREAKING)

## New Feature: `MockStrict`

Strict mocks throw a descriptive error if a method is called before configuring its behavior. Useful to catch missing stubs early.

```ts
import { MockStrict, m } from "@vdstack/mockit";

const mock = MockStrict<UserService>();
mock.getUser(1); // throws: "No behavior configured for 'getUser'"

// Configure and use normally
mock.getUser.mockReturnValue({ id: 1, name: "Test" });
mock.getUser(1); // { id: 1, name: "Test" }

// Also available via namespace
const mock2 = m.MockStrict<UserService>();

// Works with partial config
const mock3 = MockStrict<UserService>({
  getUser: m.returns({ id: 42, name: "Configured" }),
});
mock3.getUser(1);    // works
mock3.deleteUser(1); // throws: "No behavior configured for 'deleteUser'"
```

## Removed: `getMockHistory`

No longer part of the public API. Use `.calls` directly on mock functions:

```ts
mock.getUser(1);
mock.getUser(2);

mock.getUser.calls[0].args[0]; // 1
mock.getUser.calls[1].args[0]; // 2
mock.getUser.calls.length;     // 2
```
